### PR TITLE
added missing operator<<(batch, batch) and operator>>(batch, batch)

### DIFF
--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -142,6 +142,8 @@ namespace xsimd
 
     batch<int32_t, 8> operator<<(const batch<int32_t, 8>& lhs, int32_t rhs);
     batch<int32_t, 8> operator>>(const batch<int32_t, 8>& lhs, int32_t rhs);
+    batch<int32_t, 8> operator<<(const batch<int32_t, 8>& lhs, const batch<int32_t, 8>& rhs);
+    batch<int32_t, 8> operator>>(const batch<int32_t, 8>& lhs, const batch<int32_t, 8>& rhs);
 
     /*****************************************
      * batch_bool<int32_t, 8> implementation *
@@ -663,6 +665,34 @@ namespace xsimd
         __m128i res_high = _mm_srli_epi32(lhs_high, rhs);
         XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
+    }
+
+    inline batch<int32_t, 8> operator<<(const batch<int32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+        return batch<int32_t, 8>{
+            lhs[0] << rhs[0],
+            lhs[1] << rhs[1],
+            lhs[2] << rhs[2],
+            lhs[3] << rhs[3],
+            lhs[4] << rhs[4],
+            lhs[5] << rhs[5],
+            lhs[6] << rhs[6],
+            lhs[7] << rhs[7]
+            };
+    }
+
+    inline batch<int32_t, 8> operator>>(const batch<int32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+        return batch<int32_t, 8>{
+            lhs[0] >> rhs[0],
+            lhs[1] >> rhs[1],
+            lhs[2] >> rhs[2],
+            lhs[3] >> rhs[3],
+            lhs[4] >> rhs[4],
+            lhs[5] >> rhs[5],
+            lhs[6] >> rhs[6],
+            lhs[7] >> rhs[7]
+            };
     }
 }
 

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -143,6 +143,8 @@ namespace xsimd
 
     batch<int64_t, 4> operator<<(const batch<int64_t, 4>& lhs, int32_t rhs);
     batch<int64_t, 4> operator>>(const batch<int64_t, 4>& lhs, int32_t rhs);
+    batch<int64_t, 4> operator<<(const batch<int64_t, 4>& lhs, const batch<int64_t, 4>& rhs);
+    batch<int64_t, 4> operator>>(const batch<int64_t, 4>& lhs, const batch<int64_t, 4>& rhs);
 
     /*****************************************
      * batch_bool<int64_t, 4> implementation *
@@ -691,6 +693,26 @@ namespace xsimd
         __m128i res_high = _mm_srli_epi64(lhs_high, rhs);
         XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
+    }
+
+    inline batch<int64_t, 4> operator<<(const batch<int64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+        return batch<int64_t, 4>{
+            lhs[0] << rhs[0],
+            lhs[1] << rhs[1],
+            lhs[2] << rhs[2],
+            lhs[3] << rhs[3]
+            };
+    }
+
+    inline batch<int64_t, 4> operator>>(const batch<int64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+        return batch<int64_t, 4>{
+            lhs[0] >> rhs[0],
+            lhs[1] >> rhs[1],
+            lhs[2] >> rhs[2],
+            lhs[3] >> rhs[3]
+            };
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -142,6 +142,8 @@ namespace xsimd
 
     batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, int32_t rhs);
     batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, int32_t rhs);
+    batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs);
+    batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs);
 
     /*****************************************
      * batch_bool<int32_t, 4> implementation *
@@ -551,6 +553,26 @@ namespace xsimd
     inline batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, int32_t rhs)
     {
         return _mm_srli_epi32(lhs, rhs);
+    }
+
+    inline batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+        return batch<int32_t, 4>{
+            lhs[0] << rhs[0],
+            lhs[1] << rhs[1],
+            lhs[2] << rhs[2],
+            lhs[3] << rhs[3]
+            };
+    }
+
+    inline batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+        return batch<int32_t, 4>{
+            lhs[0] >> rhs[0],
+            lhs[1] >> rhs[1],
+            lhs[2] >> rhs[2],
+            lhs[3] >> rhs[3]
+            };
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -142,6 +142,8 @@ namespace xsimd
 
     batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int32_t rhs);
     batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int32_t rhs);
+    batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
+    batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
 
     /********************
      * helper functions *
@@ -566,6 +568,22 @@ namespace xsimd
     inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int32_t rhs)
     {
         return _mm_srli_epi64(lhs, rhs);
+    }
+
+    inline batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+        return batch<int64_t, 2>{
+            lhs[0] << rhs[0],
+            lhs[1] << rhs[1]
+            };
+    }
+
+    inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+        return batch<int64_t, 2>{
+            lhs[0] >> rhs[0],
+            lhs[1] >> rhs[1]
+            };
     }
 }
 


### PR DESCRIPTION
These functions are called in the corresponding xexpressions when xtensor is compiled with `XTENSOR_USE_SIMD=ON`. Specifically, tests `left_shift` and `right_shift` in `test_xoperation.cpp` fail to compile. The PR is not pretty, but seems to be the simplest solution by far.