### PR TITLE
generic logical operators

### DIFF
--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -24,6 +24,7 @@ namespace xsimd
         using value_type = bool;
         static constexpr std::size_t size = 4;
         using batch_type = batch<double, 4>;
+        static constexpr std::size_t align = 32;
     };
 
     template <>
@@ -67,6 +68,7 @@ namespace xsimd
         using value_type = double;
         static constexpr std::size_t size = 4;
         using batch_bool_type = batch_bool<double, 4>;
+        static constexpr std::size_t align = 32;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -24,6 +24,7 @@ namespace xsimd
         using value_type = bool;
         static constexpr std::size_t size = 8;
         using batch_type = batch<float, 8>;
+        static constexpr std::size_t align = 32;
     };
 
     template <>
@@ -67,6 +68,7 @@ namespace xsimd
         using value_type = float;
         static constexpr std::size_t size = 8;
         using batch_bool_type = batch_bool<float, 8>;
+        static constexpr std::size_t align = 32;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -26,6 +26,7 @@ namespace xsimd
         using value_type = bool;
         static constexpr std::size_t size = 8;
         using batch_type = batch<int32_t, 8>;
+        static constexpr std::size_t align = 32;
     };
 
     template <>
@@ -68,6 +69,7 @@ namespace xsimd
         using value_type = int32_t;
         static constexpr std::size_t size = 8;
         using batch_bool_type = batch_bool<int32_t, 8>;
+        static constexpr std::size_t align = 32;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -26,6 +26,7 @@ namespace xsimd
         using value_type = bool;
         static constexpr std::size_t size = 4;
         using batch_type = batch<int64_t, 4>;
+        static constexpr std::size_t align = 32;
     };
 
     template <>
@@ -68,6 +69,7 @@ namespace xsimd
         using value_type = int64_t;
         static constexpr std::size_t size = 4;
         using batch_bool_type = batch_bool<int64_t, 4>;
+        static constexpr std::size_t align = 32;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_base.hpp
+++ b/include/xsimd/types/xsimd_base.hpp
@@ -188,6 +188,16 @@ namespace xsimd
     template <class X>
     std::ostream& operator<<(std::ostream& out, const simd_batch<X>& rhs);
 
+    /***************************
+     * generic batch operators *
+     ***************************/
+
+    template <class T, std::size_t N>
+    batch<T, N> operator&&(const batch<T, N>& lhs, const batch<T, N>& rhs);
+
+    template <class T, std::size_t N>
+    batch<T, N> operator||(const batch<T, N>& lhs, const batch<T, N>& rhs);
+
     /**********************************
      * simd_batch_bool implementation *
      **********************************/
@@ -798,6 +808,44 @@ namespace xsimd
         }
         out << rhs()[s - 1] << ')';
         return out;
+    }
+
+    /******************************************
+     * generic batch operators implementation *
+     ******************************************/
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator&&(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        using traits = simd_batch_traits<batch<T, N>>;
+        constexpr std::size_t align = traits::align;
+        alignas(align) T tmp_lhs[N];
+        alignas(align) T tmp_rhs[N];
+        alignas(align) T tmp_res[N];
+        lhs.store_aligned(tmp_lhs);
+        rhs.store_aligned(tmp_rhs);
+        for (std::size_t i = 0; i < traits::size; ++i)
+        {
+            tmp_res[i] = tmp_lhs[i] && tmp_rhs[i];
+        }
+        return batch<T, N>(tmp_res, aligned_mode());
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator||(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        using traits = simd_batch_traits<batch<T, N>>;
+        constexpr std::size_t align = traits::align;
+        alignas(align) T tmp_lhs[N];
+        alignas(align) T tmp_rhs[N];
+        alignas(align) T tmp_res[N];
+        lhs.store_aligned(tmp_lhs);
+        rhs.store_aligned(tmp_rhs);
+        for (std::size_t i = 0; i < traits::size; ++i)
+        {
+            tmp_res[i] = tmp_lhs[i] || tmp_rhs[i];
+        }
+        return batch<T, N>(tmp_res, aligned_mode());
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_bool.hpp
+++ b/include/xsimd/types/xsimd_neon_bool.hpp
@@ -57,6 +57,7 @@ namespace xsimd
         using value_type = bool;
         static constexpr std::size_t size = 4;
         using batch_type = batch<T, 4>;
+        static constexpr std::size_t align = XSIMD_DEFAULT_ALIGNMENT;
     };
 
     template <class T>

--- a/include/xsimd/types/xsimd_neon_double.hpp
+++ b/include/xsimd/types/xsimd_neon_double.hpp
@@ -19,6 +19,7 @@ namespace xsimd
         using value_type = double;
         static constexpr std::size_t size = 2;
         using batch_bool_type = batch_bool<double, 2>;
+        static constexpr std::size_t align = XSIMD_DEFAULT_ALIGNMENT;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_neon_float.hpp
+++ b/include/xsimd/types/xsimd_neon_float.hpp
@@ -20,6 +20,7 @@ namespace xsimd
         using value_type = float;
         static constexpr std::size_t size = 4;
         using batch_bool_type = batch_bool<float, 4>;
+        static constexpr std::size_t align = XSIMD_DEFAULT_ALIGNMENT;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_neon_int32.hpp
+++ b/include/xsimd/types/xsimd_neon_int32.hpp
@@ -22,6 +22,7 @@ namespace xsimd
         using value_type = int32_t;
         static constexpr std::size_t size = 4;
         using batch_bool_type = batch_bool<int32_t, 4>;
+        static constexpr std::size_t align = XSIMD_DEFAULT_ALIGNMENT;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_neon_int64.hpp
+++ b/include/xsimd/types/xsimd_neon_int64.hpp
@@ -19,6 +19,7 @@ namespace xsimd
         using value_type = int64_t;
         static constexpr std::size_t size = 2;
         using batch_bool_type = batch_bool<int64_t, 2>;
+        static constexpr std::size_t align = XSIMD_DEFAULT_ALIGNMENT;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -24,6 +24,7 @@ namespace xsimd
         using value_type = double;
         static constexpr std::size_t size = 2;
         using batch_type = batch<double, 2>;
+        static constexpr std::size_t align = 16;
     };
 
     template <>
@@ -66,6 +67,7 @@ namespace xsimd
         using value_type = double;
         static constexpr std::size_t size = 2;
         using batch_bool_type = batch_bool<double, 2>;
+        static constexpr std::size_t align = 16;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -24,6 +24,7 @@ namespace xsimd
         using value_type = bool;
         static constexpr std::size_t size = 4;
         using batch_type = batch<float, 4>;
+        static constexpr std::size_t align = 16;
     };
 
     template <>
@@ -66,6 +67,7 @@ namespace xsimd
         using value_type = float;
         static constexpr std::size_t size = 4;
         using batch_bool_type = batch_bool<float, 4>;
+        static constexpr std::size_t align = 16;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -26,6 +26,7 @@ namespace xsimd
         using value_type = bool;
         static constexpr std::size_t size = 4;
         using batch_type = batch<int32_t, 4>;
+        static constexpr std::size_t align = 16;
     };
 
     template <>
@@ -68,6 +69,7 @@ namespace xsimd
         using value_type = int32_t;
         static constexpr std::size_t size = 4;
         using batch_bool_type = batch_bool<int32_t, 4>;
+        static constexpr std::size_t align = 16;
     };
 
     template <>

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -26,6 +26,7 @@ namespace xsimd
         using value_type = bool;
         static constexpr std::size_t size = 2;
         using batch_type = batch<int64_t, 2>;
+        static constexpr std::size_t align = 16;
     };
 
     template <>
@@ -68,6 +69,7 @@ namespace xsimd
         using value_type = int64_t;
         static constexpr std::size_t size = 2;
         using batch_bool_type = batch_bool<int64_t, 2>;
+        static constexpr std::size_t align = 16;
     };
 
     template <>

--- a/test/xsimd_basic_test.hpp
+++ b/test/xsimd_basic_test.hpp
@@ -56,6 +56,8 @@ namespace xsimd
         res_type xor_res;
         res_type not_res;
         res_type lnot_res;
+        res_type land_res;
+        res_type lor_res;
         res_type min_res;
         res_type max_res;
         res_type abs_res;
@@ -101,6 +103,8 @@ namespace xsimd
         xor_res.resize(N);
         not_res.resize(N);
         lnot_res.resize(N);
+        land_res.resize(N);
+        lor_res.resize(N);
         min_res.resize(N);
         max_res.resize(N);
         abs_res.resize(N);
@@ -135,6 +139,8 @@ namespace xsimd
             //xor_res[i] = lhs[i] ^ rhs[i];
             //not_res[i] = ~lhs[i];
             //lnot_res[i] = !lhs[i];
+            //land_res[i] = lhs[i] && rhs[i];
+            //lor_res[i] = lhs[i] || rhs[i];
             min_res[i] = min(lhs[i], rhs[i]);
             max_res[i] = max(lhs[i], rhs[i]);
             abs_res[i] = abs(lhs[i]);
@@ -191,6 +197,8 @@ namespace xsimd
         res_type xor_res;
         res_type not_res;
         res_type lnot_res;
+        res_type land_res;
+        res_type lor_res;
         res_type min_res;
         res_type max_res;
         res_type abs_res;
@@ -235,6 +243,8 @@ namespace xsimd
         xor_res.resize(N);
         not_res.resize(N);
         lnot_res.resize(N);
+        land_res.resize(N);
+        lor_res.resize(N);
         min_res.resize(N);
         max_res.resize(N);
         abs_res.resize(N);
@@ -271,6 +281,8 @@ namespace xsimd
             //xor_res[i] = lhs[i] ^ rhs[i];
             //not_res[i] = ~lhs[i];
             //lnot_res[i] = !lhs[i];
+            //land_res[i] = lhs[i] && rhs[i];
+            //lor_res[i] = lhs[i] || rhs[i];
             min_res[i] = min(lhs[i], rhs[i]);
             max_res[i] = max(lhs[i], rhs[i]);
             abs_res[i] = abs(lhs[i]);


### PR DESCRIPTION
These operators, even if not called, are required by some compilers to compile the test suite of `xtensor` with SIMD enabled.