### PR TITLE
WIP Adding a shim type (batch<T, N>)

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -21,9 +21,10 @@ set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 include(CheckCXXCompilerFlag)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Ofast -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion")
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Ofast -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion")
     CHECK_CXX_COMPILER_FLAG("-std=c++11" HAS_CPP11_FLAG)
 
     if (HAS_CPP11_FLAG)

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -6,6 +6,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#define XSIMD_FORCE_X86_INSTR_SET 0
+#define XSIMD_FORCE_X86_INSTR_SET_AVAILABLE 0
+#define XSIMD_DEFAULT_ALIGNMENT 32
+
 #include "xsimd_benchmark.hpp"
 #include <map>
 
@@ -23,12 +27,12 @@ void benchmark_exp_log()
 {
     std::size_t size = 20000;
     xsimd::run_benchmark_1op(xsimd::exp_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::exp2_fn(), std::cout, size, 100);
-    xsimd::run_benchmark_1op(xsimd::expm1_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::log_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::log2_fn(), std::cout, size, 100);
-    xsimd::run_benchmark_1op(xsimd::log10_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::log1p_fn(), std::cout, size, 1000);
+    // xsimd::run_benchmark_1op(xsimd::exp2_fn(), std::cout, size, 100);
+    // xsimd::run_benchmark_1op(xsimd::expm1_fn(), std::cout, size, 1000);
+    // xsimd::run_benchmark_1op(xsimd::log_fn(), std::cout, size, 1000);
+    // xsimd::run_benchmark_1op(xsimd::log2_fn(), std::cout, size, 100);
+    // xsimd::run_benchmark_1op(xsimd::log10_fn(), std::cout, size, 1000);
+    // xsimd::run_benchmark_1op(xsimd::log1p_fn(), std::cout, size, 1000);
 }
 
 void benchmark_trigo()
@@ -37,41 +41,41 @@ void benchmark_trigo()
     xsimd::run_benchmark_1op(xsimd::sin_fn(), std::cout, size, 1000);
     xsimd::run_benchmark_1op(xsimd::cos_fn(), std::cout, size, 1000);
     xsimd::run_benchmark_1op(xsimd::tan_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::asin_fn(), std::cout, size, 1000, xsimd::init_method::arctrigo);
-    xsimd::run_benchmark_1op(xsimd::acos_fn(), std::cout, size, 1000, xsimd::init_method::arctrigo);
-    xsimd::run_benchmark_1op(xsimd::atan_fn(), std::cout, size, 1000, xsimd::init_method::arctrigo);
+    // xsimd::run_benchmark_1op(xsimd::asin_fn(), std::cout, size, 1000, xsimd::init_method::arctrigo);
+    // xsimd::run_benchmark_1op(xsimd::acos_fn(), std::cout, size, 1000, xsimd::init_method::arctrigo);
+    // xsimd::run_benchmark_1op(xsimd::atan_fn(), std::cout, size, 1000, xsimd::init_method::arctrigo);
 }
 
-void benchmark_hyperbolic()
-{
-    std::size_t size = 20000;
-    xsimd::run_benchmark_1op(xsimd::sinh_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::cosh_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::tanh_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::asinh_fn(), std::cout, size, 100);
-    xsimd::run_benchmark_1op(xsimd::acosh_fn(), std::cout, size, 100);
-    xsimd::run_benchmark_1op(xsimd::atanh_fn(), std::cout, size, 100);
-}
+// void benchmark_hyperbolic()
+// {
+//     std::size_t size = 20000;
+//     xsimd::run_benchmark_1op(xsimd::sinh_fn(), std::cout, size, 1000);
+//     xsimd::run_benchmark_1op(xsimd::cosh_fn(), std::cout, size, 1000);
+//     xsimd::run_benchmark_1op(xsimd::tanh_fn(), std::cout, size, 1000);
+//     xsimd::run_benchmark_1op(xsimd::asinh_fn(), std::cout, size, 100);
+//     xsimd::run_benchmark_1op(xsimd::acosh_fn(), std::cout, size, 100);
+//     xsimd::run_benchmark_1op(xsimd::atanh_fn(), std::cout, size, 100);
+// }
 
-void benchmark_power()
-{
-    std::size_t size = 20000;
-    xsimd::run_benchmark_2op(xsimd::pow_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::sqrt_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::cbrt_fn(), std::cout, size, 100);
-    xsimd::run_benchmark_2op(xsimd::hypot_fn(), std::cout, size, 1000);
-}
+// void benchmark_power()
+// {
+//     std::size_t size = 20000;
+//     xsimd::run_benchmark_2op(xsimd::pow_fn(), std::cout, size, 1000);
+//     xsimd::run_benchmark_1op(xsimd::sqrt_fn(), std::cout, size, 1000);
+//     xsimd::run_benchmark_1op(xsimd::cbrt_fn(), std::cout, size, 100);
+//     xsimd::run_benchmark_2op(xsimd::hypot_fn(), std::cout, size, 1000);
+// }
 
-void benchmark_rounding()
-{
-    std::size_t size = 20000;
-    xsimd::run_benchmark_1op(xsimd::ceil_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::floor_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::trunc_fn(), std::cout, size, 1000);
-    xsimd::run_benchmark_1op(xsimd::round_fn(), std::cout, size, 100);
-    xsimd::run_benchmark_1op(xsimd::nearbyint_fn(), std::cout, size, 100);
-    xsimd::run_benchmark_1op(xsimd::rint_fn(), std::cout, size, 100);
-}
+// void benchmark_rounding()
+// {
+//     std::size_t size = 20000;
+//     xsimd::run_benchmark_1op(xsimd::ceil_fn(), std::cout, size, 1000);
+//     xsimd::run_benchmark_1op(xsimd::floor_fn(), std::cout, size, 1000);
+//     xsimd::run_benchmark_1op(xsimd::trunc_fn(), std::cout, size, 1000);
+//     xsimd::run_benchmark_1op(xsimd::round_fn(), std::cout, size, 100);
+//     xsimd::run_benchmark_1op(xsimd::nearbyint_fn(), std::cout, size, 100);
+//     xsimd::run_benchmark_1op(xsimd::rint_fn(), std::cout, size, 100);
+// }
 
 int main(int argc, char* argv[])
 {
@@ -81,9 +85,9 @@ int main(int argc, char* argv[])
         fn_map["op"] = benchmark_operation;
         fn_map["exp"] = benchmark_exp_log;
         fn_map["trigo"] = benchmark_trigo;
-        fn_map["hyperbolic"] = benchmark_hyperbolic;
-        fn_map["power"] = benchmark_power;
-        fn_map["rounding"] = benchmark_rounding;
+        // fn_map["hyperbolic"] = benchmark_hyperbolic;
+        // fn_map["power"] = benchmark_power;
+        // fn_map["rounding"] = benchmark_rounding;
 
         if (std::string(argv[1]) == "--help" || std::string(argv[1]) == "-h")
         {
@@ -108,9 +112,9 @@ int main(int argc, char* argv[])
         benchmark_operation();
         benchmark_exp_log();
         benchmark_trigo();
-        benchmark_hyperbolic();
-        benchmark_power();
-        benchmark_rounding();
+        // benchmark_hyperbolic();
+        // benchmark_power();
+        // benchmark_rounding();
     }
     return 0;
 }

--- a/benchmark/xsimd_benchmark.hpp
+++ b/benchmark/xsimd_benchmark.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
+#include "../include/xsimd/types/xsimd_shim.hpp"
 #include "xsimd/xsimd.hpp"
 
 namespace xsimd
@@ -63,7 +64,7 @@ namespace xsimd
     };
 
     template <class F, class V>
-    duration_type benchmark_scalar(F f, V& lhs, V& res, std::size_t number)
+    duration_type benchmark_scalar(const F& f, V& lhs, V& res, std::size_t number)
     {
         size_t s = lhs.size();
         duration_type t_res = duration_type::max();
@@ -82,7 +83,7 @@ namespace xsimd
     }
 
     template <class F, class V>
-    duration_type benchmark_scalar(F f, V& lhs, V& rhs, V& res, std::size_t number)
+    duration_type benchmark_scalar(const F& f, V& lhs, V& rhs, V& res, std::size_t number)
     {
         size_t s = lhs.size();
         duration_type t_res = duration_type::max();
@@ -101,7 +102,7 @@ namespace xsimd
     }
 
     template <class B, class F, class V>
-    duration_type benchmark_simd(F f, V& lhs, V& res, std::size_t number)
+    duration_type benchmark_simd(const F& f, V& lhs, V& res, std::size_t number)
     {
         std::size_t s = lhs.size();
         duration_type t_res = duration_type::max();
@@ -122,7 +123,7 @@ namespace xsimd
     }
 
     template <class B, class F, class V>
-    duration_type benchmark_simd_unrolled(F f, V& lhs, V& res, std::size_t number)
+    duration_type benchmark_simd_unrolled(const F& f, V& lhs, V& res, std::size_t number)
     {
         std::size_t s = lhs.size();
         std::size_t inc = 4 * B::size;
@@ -239,12 +240,10 @@ namespace xsimd
         duration_type t_double_sse = benchmark_simd<batch<double, 2>>(f, d_lhs, d_res, iter);
         duration_type t_double_sse_u = benchmark_simd_unrolled<batch<double, 2>>(f, d_lhs, d_res, iter);
 #endif
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
         duration_type t_float_avx = benchmark_simd<batch<float, 8>>(f, f_lhs, f_res, iter);
         duration_type t_float_avx_u = benchmark_simd_unrolled<batch<float, 8>>(f, f_lhs, f_res, iter);
         duration_type t_double_avx = benchmark_simd<batch<double, 4>>(f, d_lhs, d_res, iter);
         duration_type t_double_avx_u = benchmark_simd_unrolled<batch<double, 4>>(f, d_lhs, d_res, iter);
-#endif
 #if defined(XSIMD_ARM_INSTR_SET)
         duration_type t_float_neon = benchmark_simd<batch<float, 4>>(f, f_lhs, f_res, iter);
         duration_type t_float_neon_u = benchmark_simd_unrolled<batch<float, 4>>(f, f_lhs, f_res, iter);
@@ -259,10 +258,8 @@ namespace xsimd
         out << "sse float      : " << t_float_sse.count() << "ms" << std::endl;
         out << "sse float unr  : " << t_float_sse_u.count() << "ms" << std::endl;
 #endif
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
         out << "avx float      : " << t_float_avx.count() << "ms" << std::endl;
         out << "avx float unr  : " << t_float_avx_u.count() << "ms" << std::endl;
-#endif
 #if defined(XSIMD_ARM_INSTR_SET)
         out << "neon float     : " << t_float_neon.count() << "ms" << std::endl;
         out << "neon float unr : " << t_float_neon_u.count() << "ms" << std::endl;
@@ -272,10 +269,8 @@ namespace xsimd
         out << "sse double     : " << t_double_sse.count() << "ms" << std::endl;
         out << "sse double unr : " << t_double_sse_u.count() << "ms" << std::endl;
 #endif
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
         out << "avx double     : " << t_double_avx.count() << "ms" << std::endl;
         out << "avx double unr : " << t_double_avx_u.count() << "ms" << std::endl;
-#endif
 #if defined(XSIMD_ARM_INSTR_SET)
         out << "neon double    : " << t_double_neon.count() << "ms" << std::endl;
         out << "neon double unr: " << t_double_neon_u.count() << "ms" << std::endl;
@@ -292,80 +287,87 @@ namespace xsimd
         init_benchmark(f_lhs, f_rhs, f_res, size);
         init_benchmark(d_lhs, d_rhs, d_res, size);
 
-        duration_type t_float_scalar = benchmark_scalar(f, f_lhs, f_rhs, f_res, iter);
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
-        duration_type t_float_sse = benchmark_simd<batch<float, 4>>(f, f_lhs, f_rhs, f_res, iter);
-        duration_type t_float_sse_u = benchmark_simd_unrolled<batch<float, 4>>(f, f_lhs, f_rhs, f_res, iter);
-#endif
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
-        duration_type t_float_avx = benchmark_simd<batch<float, 8>>(f, f_lhs, f_rhs, f_res, iter);
-        duration_type t_float_avx_u = benchmark_simd_unrolled<batch<float, 8>>(f, f_lhs, f_rhs, f_res, iter);
-#endif
+        // duration_type t_float_scalar = benchmark_scalar(f, f_lhs, f_rhs, f_res, iter);
+// #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
+//         duration_type t_float_sse = benchmark_simd<batch<float, 4>>(f, f_lhs, f_rhs, f_res, iter);
+//         duration_type t_float_sse_u = benchmark_simd_unrolled<batch<float, 4>>(f, f_lhs, f_rhs, f_res, iter);
+// #endif
+// #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
+//         duration_type t_float_avx = benchmark_simd<batch<float, 8>>(f, f_lhs, f_rhs, f_res, iter);
+//         duration_type t_float_avx_u = benchmark_simd_unrolled<batch<float, 8>>(f, f_lhs, f_rhs, f_res, iter);
+// #endif
         duration_type t_double_scalar = benchmark_scalar(f, d_lhs, d_rhs, d_res, iter);
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
-        duration_type t_double_sse = benchmark_simd<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
-        duration_type t_double_sse_u = benchmark_simd_unrolled<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
-#endif
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
-        duration_type t_double_avx = benchmark_simd<batch<double, 4>>(f, d_lhs, d_rhs, d_res, iter);
-        duration_type t_double_avx_u = benchmark_simd_unrolled<batch<double, 4>>(f, d_lhs, d_rhs, d_res, iter);
-#endif
-#if defined(XSIMD_ARM_INSTR_SET)
-        duration_type t_float_neon = benchmark_simd<batch<float, 4>>(f, f_lhs, f_rhs, f_res, iter);
-        duration_type t_float_neon_u = benchmark_simd_unrolled<batch<float, 4>>(f, f_lhs, f_rhs, f_res, iter);
-        duration_type t_double_neon = benchmark_simd<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
-        duration_type t_double_neon_u = benchmark_simd_unrolled<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
-#endif
+// #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
+//         duration_type t_double_sse = benchmark_simd<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
+//         duration_type t_double_sse_u = benchmark_simd_unrolled<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
+// #endif
+// #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
+//         duration_type t_double_avx = benchmark_simd<batch<double, 4>>(f, d_lhs, d_rhs, d_res, iter);
+//         duration_type t_double_avx_u = benchmark_simd_unrolled<batch<double, 4>>(f, d_lhs, d_rhs, d_res, iter);
+// #endif
+// #if defined(XSIMD_ARM_INSTR_SET)
+//         duration_type t_float_neon = benchmark_simd<batch<float, 4>>(f, f_lhs, f_rhs, f_res, iter);
+//         duration_type t_float_neon_u = benchmark_simd_unrolled<batch<float, 4>>(f, f_lhs, f_rhs, f_res, iter);
+//         duration_type t_double_neon = benchmark_simd<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
+//         duration_type t_double_neon_u = benchmark_simd_unrolled<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
+// #endif
+
+        duration_type t_shim = benchmark_simd<batch<double, 8>>(f, d_lhs, d_rhs, d_res, iter);
+        duration_type t_shim_u = benchmark_simd_unrolled<batch<double, 8>>(f, d_lhs, d_rhs, d_res, iter);
+
 
         out << "============================" << std::endl;
         out << f.name() << std::endl;
-        out << "scalar float   : " << t_float_scalar.count() << "ms" << std::endl;
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
-        out << "sse float      : " << t_float_sse.count() << "ms" << std::endl;
-        out << "sse float unr  : " << t_float_sse_u.count() << "ms" << std::endl;
-#endif
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
-        out << "avx float      : " << t_float_avx.count() << "ms" << std::endl;
-        out << "avx float unr  : " << t_float_avx_u.count() << "ms" << std::endl;
-#endif
-#if defined(XSIMD_ARM_INSTR_SET)
-        out << "neon float     : " << t_float_neon.count() << "ms" << std::endl;
-        out << "neon float unr : " << t_float_neon_u.count() << "ms" << std::endl;
-#endif
+//         out << "scalar float   : " << t_float_scalar.count() << "ms" << std::endl;
+// #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
+//         out << "sse float      : " << t_float_sse.count() << "ms" << std::endl;
+//         out << "sse float unr  : " << t_float_sse_u.count() << "ms" << std::endl;
+// #endif
+// #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
+//         out << "avx float      : " << t_float_avx.count() << "ms" << std::endl;
+//         out << "avx float unr  : " << t_float_avx_u.count() << "ms" << std::endl;
+// #endif
+// #if defined(XSIMD_ARM_INSTR_SET)
+//         out << "neon float     : " << t_float_neon.count() << "ms" << std::endl;
+//         out << "neon float unr : " << t_float_neon_u.count() << "ms" << std::endl;
+// #endif
         out << "scalar double  : " << t_double_scalar.count() << "ms" << std::endl;
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
-        out << "sse double     : " << t_double_sse.count() << "ms" << std::endl;
-        out << "sse double unr : " << t_double_sse_u.count() << "ms" << std::endl;
-#endif
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
-        out << "avx double     : " << t_double_avx.count() << "ms" << std::endl;
-        out << "avx double unr : " << t_double_avx_u.count() << "ms" << std::endl;
-#endif
-#if defined(XSIMD_ARM_INSTR_SET)
-        out << "neon double    : " << t_double_neon.count() << "ms" << std::endl;
-        out << "neon double unr: " << t_double_neon_u.count() << "ms" << std::endl;
-#endif
-        out << "============================" << std::endl;
+        out << "shim double    : " << t_shim.count() << "ms" << std::endl;
+        out << "shim double unr: " << t_shim_u.count() << "ms" << std::endl;
+
+// #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
+//         out << "sse double     : " << t_double_sse.count() << "ms" << std::endl;
+//         out << "sse double unr : " << t_double_sse_u.count() << "ms" << std::endl;
+// #endif
+// #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
+//         out << "avx double     : " << t_double_avx.count() << "ms" << std::endl;
+//         out << "avx double unr : " << t_double_avx_u.count() << "ms" << std::endl;
+// #endif
+// #if defined(XSIMD_ARM_INSTR_SET)
+//         out << "neon double    : " << t_double_neon.count() << "ms" << std::endl;
+//         out << "neon double unr: " << t_double_neon_u.count() << "ms" << std::endl;
+// #endif
+//         out << "============================" << std::endl;
     }
 
 #define DEFINE_OP_FUNCTOR_2OP(OP, NAME)\
     struct NAME##_fn {\
         template <class T>\
-        inline T operator()(const T& lhs, const T& rhs) const { return lhs OP rhs; }\
+        __attribute__((always_inline)) constexpr T operator()(T lhs, T rhs) const { return lhs OP rhs; }\
         inline std::string name() const { return #NAME; }\
     }
 
 #define DEFINE_FUNCTOR_1OP(FN)\
     struct FN##_fn {\
         template <class T>\
-        inline T operator()(const T& x) const { using std::FN; using xsimd::FN; return FN(x); }\
+        __attribute__((always_inline)) constexpr T operator()(T x) const { using std::FN; using xsimd::FN; return FN(x); }\
         inline std::string name() const { return #FN; }\
     }
 
 #define DEFINE_FUNCTOR_2OP(FN)\
     struct FN##_fn{\
         template <class T>\
-        inline T operator()(const T&lhs, const T& rhs) const { using std::FN; using xsimd::FN; return FN(lhs, rhs); }\
+        __attribute__((always_inline)) constexpr T operator()(T lhs, T rhs) const { using std::FN; using xsimd::FN; return FN(lhs, rhs); }\
         inline std::string name() const { return #FN; }\
     }
 

--- a/include/xsimd/config/xsimd_instruction_set.hpp
+++ b/include/xsimd/config/xsimd_instruction_set.hpp
@@ -176,7 +176,7 @@
     #elif __ARM_ARCH >= 7
         #define XSIMD_ARM_INSTR_SET XSIMD_ARM7_NEON_VERSION
     #else
-        static_assert("NEON instruction set not supported.", false);
+        static_assert(false, "NEON instruction set not supported.");
     #endif
 #endif
 

--- a/include/xsimd/math/xsimd_exp_reduction.hpp
+++ b/include/xsimd/math/xsimd_exp_reduction.hpp
@@ -12,6 +12,7 @@
 #include "xsimd_horner.hpp"
 #include "xsimd_numerical_constant.hpp"
 #include "xsimd_rounding.hpp"
+#include <iostream>
 
 namespace xsimd
 {

--- a/include/xsimd/math/xsimd_exponential.hpp
+++ b/include/xsimd/math/xsimd_exponential.hpp
@@ -11,6 +11,7 @@
 
 #include "xsimd_exp_reduction.hpp"
 #include "xsimd_fp_manipulation.hpp"
+#include <iostream>
 
 namespace xsimd
 {

--- a/include/xsimd/math/xsimd_rounding.hpp
+++ b/include/xsimd/math/xsimd_rounding.hpp
@@ -157,10 +157,10 @@ namespace xsimd
         return s ^ select(v < t2n, d0 - t2n, v);
     }
 
-    template <>
-    inline batch<float, 4> trunc(const batch<float, 4>& x)
+    template <class T, std::size_t N>
+    inline batch<T, N> trunc(const batch<T, N>& x)
     {
-        using btype = batch<float, 4>;
+        using btype = batch<T, N>;
         return select(abs(x) < maxflint<btype>(), to_float(to_int(x)), x);
     }
 

--- a/include/xsimd/memory/xsimd_aligned_allocator.hpp
+++ b/include/xsimd/memory/xsimd_aligned_allocator.hpp
@@ -171,7 +171,7 @@ namespace xsimd
     aligned_allocator<T, A>::allocate(size_type n,
             typename std::allocator<void>::const_pointer) -> pointer
     {
-        pointer res = reinterpret_cast<pointer>(aligned_malloc(sizeof(T) * n, A));
+        pointer res = reinterpret_cast<pointer>(__builtin_assume_aligned(aligned_malloc(sizeof(T) * n, A), XSIMD_DEFAULT_ALIGNMENT));
         if (res == nullptr)
             throw std::bad_alloc();
         return res;

--- a/include/xsimd/types/xsimd_avx_conversion.hpp
+++ b/include/xsimd/types/xsimd_avx_conversion.hpp
@@ -40,17 +40,17 @@ namespace xsimd
      * bitwise cast functions *
      **************************/
 
-    template <class B>
-    B bitwise_cast(const batch<float, 8>& x);
+    // template <class B>
+    // B bitwise_cast(const batch<float, 8>& x);
 
-    template <class B>
-    B bitwise_cast(const batch<double, 4>& x);
+    // template <class B>
+    // B bitwise_cast(const batch<double, 4>& x);
 
-    template <class B>
-    B bitwise_cast(const batch<int32_t, 8>& x);
+    // template <class B>
+    // B bitwise_cast(const batch<int32_t, 8>& x);
 
-    template <class B>
-    B bitwise_cast(const batch<int64_t, 4>& x);
+    // template <class B>
+    // B bitwise_cast(const batch<int64_t, 4>& x);
 
     /***************************************
      * conversion functions implementation *
@@ -116,17 +116,56 @@ namespace xsimd
      * bitwise cast functions implementation *
      *****************************************/
 
+    namespace detail
+    {
+        template <>
+        struct batch_caster<double, int64_t, 4>
+        {
+            batch<int64_t, 4> bitwise(const batch<double, 4>& x)
+            {
+                return _mm256_castpd_si256(x);
+            }
+        };
+
+        template <>
+        struct batch_caster<float, int32_t, 8>
+        {
+            batch<int64_t, 4> bitwise(const batch<double, 4>& x)
+            {
+                return _mm256_castsi256_ps(x);
+            }
+        };
+
+        template <>
+        struct batch_caster<int64_t, double, 4>
+        {
+            batch<double, 4> bitwise(const batch<int64_t, 4>& x)
+            {
+                return _mm256_castsi256_pd(x);
+            }
+        };
+
+        template <>
+        struct batch_caster<float, int32_t, 8>
+        {
+            batch<int32_t, 8> bitwise(const batch<float, 8>& x)
+            {
+                return _mm256_castps_si256(x);
+            }
+        };
+    }
+
     template <>
     inline batch<double, 4> bitwise_cast(const batch<float, 8>& x)
     {
         return _mm256_castps_pd(x);
     }
 
-    template <>
-    inline batch<int32_t, 8> bitwise_cast(const batch<float, 8>& x)
-    {
-        return _mm256_castps_si256(x);
-    }
+    // template <>
+    // inline batch<int32_t, 8> bitwise_cast(const batch<float, 8>& x)
+    // {
+    //     return _mm256_castps_si256(x);
+    // }
 
     template <>
     inline batch<int64_t, 4> bitwise_cast(const batch<float, 8>& x)
@@ -146,17 +185,17 @@ namespace xsimd
         return _mm256_castpd_si256(x);
     }
 
-    template <>
-    inline batch<int64_t, 4> bitwise_cast(const batch<double, 4>& x)
-    {
-        return _mm256_castpd_si256(x);
-    }
+    // template <>
+    // inline batch<int64_t, 4> bitwise_cast(const batch<double, 4>& x)
+    // {
+    //     return _mm256_castpd_si256(x);
+    // }
 
-    template <>
-    inline batch<float, 8> bitwise_cast(const batch<int32_t, 8>& x)
-    {
-        return _mm256_castsi256_ps(x);
-    }
+    // template <>
+    // inline batch<float, 8> bitwise_cast(const batch<int32_t, 8>& x)
+    // {
+    //     return _mm256_castsi256_ps(x);
+    // }
 
     template <>
     inline batch<double, 4> bitwise_cast(const batch<int32_t, 8>& x)
@@ -170,11 +209,11 @@ namespace xsimd
         return _mm256_castsi256_ps(x);
     }
 
-    template <>
-    inline batch<double, 4> bitwise_cast(const batch<int64_t, 4>& x)
-    {
-        return _mm256_castsi256_pd(x);
-    }
+    // template <>
+    // inline batch<double, 4> bitwise_cast(const batch<int64_t, 4>& x)
+    // {
+    //     return _mm256_castsi256_pd(x);
+    // }
 }
 
 #endif

--- a/include/xsimd/types/xsimd_base.hpp
+++ b/include/xsimd/types/xsimd_base.hpp
@@ -188,6 +188,9 @@ namespace xsimd
     template <class X>
     std::ostream& operator<<(std::ostream& out, const simd_batch<X>& rhs);
 
+    template <class X>
+    std::ostream& operator<<(std::ostream& out, const simd_batch_bool<X>& rhs);
+
     /**********************************
      * simd_batch_bool implementation *
      **********************************/
@@ -791,6 +794,19 @@ namespace xsimd
     inline std::ostream& operator<<(std::ostream& out, const simd_batch<X>& rhs)
     {
         out << '(';
+        std::size_t s = simd_batch<X>::size;
+        for (std::size_t i = 0; i < s - 1; ++i)
+        {
+            out << rhs()[i] << ", ";
+        }
+        out << rhs()[s - 1] << ')';
+        return out;
+    }
+
+    template <class X>
+    inline std::ostream& operator<<(std::ostream& out, const simd_batch_bool<X>& rhs)
+    {
+        out << std::boolalpha << '(';
         std::size_t s = simd_batch<X>::size;
         for (std::size_t i = 0; i < s - 1; ++i)
         {

--- a/include/xsimd/types/xsimd_shim.hpp
+++ b/include/xsimd/types/xsimd_shim.hpp
@@ -1,0 +1,749 @@
+/***************************************************************************
+* Copyright (c) 2016, Wolf Vollprecht, Johan Mabille and Sylvain Corlay    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSIMD_SHIM_HPP
+#define XSIMD_SHIM_HPP
+
+#include <cmath>
+
+#include "xsimd_base.hpp"
+
+namespace xsimd
+{
+
+    namespace detail 
+    {
+        template <class T>
+        struct get_int_type
+        {
+            using signed_type = typename std::make_signed<T>::type;
+            using unsigned_type = typename std::make_unsigned<T>::type;
+        };
+
+        template <>
+        struct get_int_type<float>
+        {
+            using signed_type = int32_t;
+            using unsigned_type = uint32_t;
+        };
+
+        template <>
+        struct get_int_type<double>
+        {
+            using signed_type = int64_t;
+            using unsigned_type = uint64_t;
+        };
+
+        template <class T>
+        struct get_float_type;
+
+        template <>
+        struct get_float_type<int32_t>
+        {
+            using type = float;
+        };
+
+        template <>
+        struct get_float_type<int64_t>
+        {
+            using type = double;
+        };
+    }
+
+    /*************************
+     * batch_bool<T, N> *
+     *************************/
+
+    template <class T, std::size_t N>
+    struct simd_batch_traits<batch_bool<T, N>>
+    {
+        using value_type = typename detail::get_int_type<T>::unsigned_type;
+        static constexpr std::size_t size = N;
+        using batch_bool_type = batch_bool<T, N>;
+    };
+
+    template <class T, std::size_t N>
+    class batch_bool : public simd_batch_bool<batch_bool<T, N>>
+    {
+
+    public:
+        using b_type = typename detail::get_int_type<T>::unsigned_type;
+        using type = std::array<b_type, N>;
+
+        batch_bool();
+        template <class... Args>
+        explicit batch_bool(Args... b);
+        batch_bool(const batch<T, N>& rhs);
+        batch_bool& operator=(const batch<T, N>& rhs);
+
+        b_type& operator[](std::size_t index);
+        const b_type& operator[](std::size_t index) const;
+
+        operator type() const;
+
+    private:
+
+        type m_value;
+    };
+
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator&(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator|(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator^(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator~(const batch_bool<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch_bool<T, N> bitwise_andnot(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator==(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator!=(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+
+    template <class T, std::size_t N>
+    bool all(const batch_bool<T, N>& rhs);
+    template <class T, std::size_t N>
+    bool any(const batch_bool<T, N>& rhs);
+
+    /********************
+     * batch<T, N> impl *
+     ********************/
+
+    template <class T, std::size_t N>
+    struct simd_batch_traits<batch<T, N>>
+    {
+        using value_type = T;
+        static constexpr std::size_t size = N;
+        using batch_bool_type = batch_bool<T, N>;
+    };
+
+    template <class T, std::size_t N>
+    class batch : public simd_batch<batch<T, N>>
+    {
+
+    public:
+        using self_type = batch<T, N>;
+        using storage_type = std::array<T, N>;
+        using value_type = T;
+
+        batch();
+        batch(T src);
+        batch(const batch<T, N>& src);
+        batch(const storage_type& src);
+        // template <class... Args>
+        // batch(Args... args);
+        explicit batch(const T* src);
+        batch(const T* src, aligned_mode);
+        batch(const T* src, unaligned_mode);
+        batch& operator=(const storage_type& rhs);
+        batch& operator=(const T& rhs);
+
+        operator storage_type() const;
+
+        batch& load_aligned(const double* src);
+        batch& load_unaligned(const double* src);
+
+        void store_aligned(double* dst) const;
+        void store_unaligned(double* dst) const;
+
+        T& operator[](std::size_t index);
+        const T& operator[](std::size_t index) const;
+
+    private:
+
+        storage_type m_value;
+    };
+
+    template <class T, std::size_t N>
+    batch<T, N> operator-(const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> operator+(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> operator-(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> operator*(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> operator/(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator==(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator!=(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator<(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch_bool<T, N> operator<=(const batch<T, N>& lhs, const batch<T, N>& rhs);
+
+    template <class T, std::size_t N>
+    batch<T, N> operator&(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> operator|(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> operator^(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> operator~(const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> bitwise_andnot(const batch<T, N>& lhs, const batch<T, N>& rhs);
+
+    template <class T, std::size_t N>
+    batch<T, N> min(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> max(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> fmin(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> fmax(const batch<T, N>& lhs, const batch<T, N>& rhs);
+
+    template <class T, std::size_t N>
+    batch<T, N> abs(const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> sqrt(const batch<T, N>& rhs);
+
+    template <class T, std::size_t N>
+    batch<T, N> fma(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z);
+    template <class T, std::size_t N>
+    batch<T, N> fms(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z);
+    template <class T, std::size_t N>
+    batch<T, N> fnma(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z);
+    template <class T, std::size_t N>
+    batch<T, N> fnms(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z);
+
+    template <class T, std::size_t N>
+    double hadd(const batch<T, N>& rhs);
+    template <class T, std::size_t N>
+    batch<T, N> haddp(const batch<T, N>* row);
+
+    template <class T, std::size_t N>
+    batch<T, N> select(const batch_bool<T, N>& cond, const batch<T, N>& a, const batch<T, N>& b);
+
+    template <class T, std::size_t N>
+    batch_bool<T, N> is_nan(const batch<T, N>& x);
+
+    /****************************************
+     * batch_bool<T, N> implementation *
+     ****************************************/
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N>::batch_bool()
+    {
+    }
+
+    template <class T, std::size_t N>
+    template <class... Args>
+    inline batch_bool<T, N>::batch_bool(Args... b)
+        : m_value{b...}
+    {
+    }
+
+    // template <class T, std::size_t N>
+    // inline batch_bool<T, N>::batch_bool(const T& rhs)
+    //     : m_value(rhs)
+    // {
+    // }
+
+    // template <class T, std::size_t N>
+    // inline batch_bool<T, N>& batch_bool<T, N>::operator=(const T& rhs)
+    // {
+    //     m_value = rhs;
+    //     return *this;
+    // }
+
+#define OP_MACRO(op)                                                                     \
+    batch<T, N> tmp;                                                                     \
+    for (std::size_t i = 0; i < N; ++i)                                                  \
+    {                                                                                    \
+        tmp[i] = lhs[i] op rhs[i];                                                       \
+    }                                                                                    \
+    return tmp;                                                                          \
+
+#define UNARY_OP_MACRO(op)                                                               \
+    batch<T, N> tmp;                                                                     \
+    for (std::size_t i = 0; i < N; ++i)                                                  \
+    {                                                                                    \
+        tmp[i] = op rhs[i];                                                              \
+    }                                                                                    \
+    return tmp;                                                                          \
+
+#define BOOL_OP_MACRO(op)                                                                \
+    using int_t = typename detail::get_int_type<T>::unsigned_type;                       \
+    batch_bool<T, N> tmp;                                                                \
+    for (std::size_t i = 0; i < N; ++i)                                                  \
+    {                                                                                    \
+        tmp[i] = lhs[i] op rhs[i];                                                       \
+    }                                                                                    \
+    return tmp;                                                                          \
+
+#define BITWISE_OP_MACRO(op)                                                             \
+    using int_t = typename detail::get_int_type<T>::unsigned_type;                       \
+    batch<T, N> tmp;                                                                     \
+    for (std::size_t i = 0; i < N; ++i)                                                  \
+    {                                                                                    \
+        int_t it = (*reinterpret_cast<const int_t*>(&lhs[i])) op (*reinterpret_cast<const int_t*>(&rhs[i])); \
+        tmp[i] = *reinterpret_cast<T*>(&it);                                             \
+    }                                                                                    \
+    return tmp;                                                                          \
+
+#define BOOL_MACRO(op)                                                                   \
+    using int_t = typename detail::get_int_type<T>::unsigned_type;                       \
+    batch_bool<T, N> tmp;                                                                \
+    for (std::size_t i = 0; i < N; ++i)                                                  \
+    {                                                                                    \
+        tmp[i] = static_cast<T>(static_cast<int_t>(lhs) op static_cast<int_t>(rhs));     \
+    }                                                                                    \
+    return tmp;                                                                          \
+
+#define BOOL_MACRO_UNARY(op)                                                             \
+    using int_t = typename detail::get_int_type<T>::unsigned_type;                       \
+    batch_bool<T, N> tmp;                                                                \
+    for (std::size_t i = 0; i < N; ++i)                                                  \
+    {                                                                                    \
+        tmp[i] = static_cast<T>(op static_cast<int_t>(lhs));                             \
+    }                                                                                    \
+    return tmp;                                                                          \
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N>::operator type() const
+    {
+        return m_value;
+    }
+
+    template <class T, std::size_t N>
+    inline typename batch_bool<T, N>::b_type& batch_bool<T, N>::operator[](std::size_t index)
+    {
+        return m_value[index];
+    }
+
+    template <class T, std::size_t N>
+    inline const typename batch_bool<T, N>::b_type& batch_bool<T, N>::operator[](std::size_t index) const
+    {
+        return m_value[index];
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator&(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        BOOL_MACRO(&);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator|(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        BOOL_MACRO(|);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator^(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        BOOL_MACRO(^);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator~(const batch_bool<T, N>& rhs)
+    {
+        return static_cast<double>(~static_cast<uint64_t>(double(rhs)));
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> bitwise_andnot(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        lhs & (~rhs);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator==(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        BOOL_MACRO(==);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator!=(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        BOOL_MACRO(!=)
+    }
+
+    template <class T, std::size_t N>
+    inline bool all(const batch_bool<T, N>& rhs)
+    {
+        bool result = true;
+        for (std::size_t i = 0; i < N; ++i)
+        {
+            result = result && (bool(rhs[i]));
+        }
+    }
+
+    template <class T, std::size_t N>
+    inline bool any(const batch_bool<T, N>& rhs)
+    {
+        for (std::size_t i = 0; i < N; ++i)
+        {
+            if (rhs[i])
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /***********************************
+     template <class T, std::size_t N>
+     * batch<T, N> implementation *
+     ***********************************/
+
+    template <class T, std::size_t N>
+    inline batch<T, N>::batch()
+    {
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N>::batch(T rhs)
+    {
+        std::fill(m_value.begin(), m_value.end(), rhs);
+    }
+
+    // template <class T, std::size_t N>
+    // template <class... Args>
+    // inline batch<T, N>::batch(Args... args)
+    //     : m_value({args...})
+    // {
+    // }
+
+    template <class T, std::size_t N>
+    inline batch<T, N>::batch(const T* src)
+    {
+        std::copy(src, src + N, m_value.begin());
+    }
+    
+    template <class T, std::size_t N>
+    inline batch<T, N>::batch(const T* src, aligned_mode)
+        : batch(src)
+    {
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N>::batch(const T* src, unaligned_mode)
+        : batch(src)
+    {
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N>::batch(const storage_type& d)
+        : m_value({d})
+    {
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N>::batch(const batch<T, N>& lhs)
+        : m_value(lhs.m_value)
+    {
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::operator=(const T& rhs)
+    {
+        std::fill(m_value.begin(), m_value.end(), rhs);
+        return *this;
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N>::operator storage_type() const
+    {
+        return m_value;
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::load_aligned(const double* src)
+    {
+        std::copy(src, src + N, m_value.begin());
+        return *this;
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::load_unaligned(const double* src)
+    {
+        return load_aligned(src);
+    }
+
+    template <class T, std::size_t N>
+    inline void batch<T, N>::store_aligned(double* dst) const
+    {
+        std::copy(m_value.begin(), m_value.end(), dst);
+    }
+
+    template <class T, std::size_t N>
+    inline void batch<T, N>::store_unaligned(double* dst) const
+    {
+        store_aligned(dst);
+    }
+
+    template <class T, std::size_t N>
+    inline T& batch<T, N>::operator[](std::size_t index)
+    {
+        return m_value[index];
+    }
+
+    template <class T, std::size_t N>
+    inline const T& batch<T, N>::operator[](std::size_t index) const
+    {
+        return m_value[index];
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator-(const batch<T, N>& rhs)
+    {
+        UNARY_OP_MACRO(-);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator+(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        OP_MACRO(+);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator-(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        OP_MACRO(-);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator*(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        OP_MACRO(*);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator/(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        OP_MACRO(/);
+    }
+    
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator==(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        BOOL_OP_MACRO(==);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator!=(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        BOOL_OP_MACRO(!=);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator<(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        BOOL_OP_MACRO(<);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator<=(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        BOOL_OP_MACRO(<=);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator>(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        BOOL_OP_MACRO(>);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> operator>=(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        BOOL_OP_MACRO(>=);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator&(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        BITWISE_OP_MACRO(&);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator|(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        BITWISE_OP_MACRO(|);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator^(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        BITWISE_OP_MACRO(^);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> operator~(const batch<T, N>& rhs)
+    {
+        return static_cast<double>(~static_cast<uint64_t>(double(rhs)));
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> bitwise_andnot(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        return static_cast<double>(static_cast<uint64_t>(double(lhs)) & (~static_cast<uint64_t>(double(rhs))));
+    }
+
+#define EXPR_MACRO(expr)                                                                 \
+    batch<T, N> tmp;                                                                     \
+    for (std::size_t i = 0; i < N; ++i)                                                  \
+    {                                                                                    \
+        tmp[i] = expr;                                                                   \
+    }                                                                                    \
+    return tmp;                                                                          \
+
+    template <class T, std::size_t N>
+    inline batch<T, N> min(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        EXPR_MACRO(lhs[i] < rhs[i] ? lhs[i] : rhs[i]);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> max(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        EXPR_MACRO(lhs[i] > rhs[i] ? lhs[i] : rhs[i]);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> fmin(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        return min(lhs, rhs);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> fmax(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        return max(lhs, rhs);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> abs(const batch<T, N>& rhs)
+    {
+        EXPR_MACRO(std::abs(rhs[i]));
+    }
+    
+    template <class T, std::size_t N>
+    inline batch<T, N> sqrt(const batch<T, N>& rhs)
+    {
+        EXPR_MACRO(std::sqrt(rhs[i]));
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> fma(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z)
+    {
+        EXPR_MACRO(x[i] * y[i] + z[i]);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> fms(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z)
+    {
+        EXPR_MACRO(x[i] * y[i] - z[i]);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> fnma(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z)
+    {
+        EXPR_MACRO(-x[i] * y[i] + z[i]);
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> fnms(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z)
+    {
+        EXPR_MACRO(-x[i] * y[i] - z[i]);
+    }
+
+    template <class T, std::size_t N>
+    inline T hadd(const batch<T, N>& rhs)
+    {
+        T result;
+        for (std::size_t i = 0; i < N; ++i)
+        {
+            result += rhs[i];
+        }
+        return result;
+    }
+    // TODO add tests for these functions
+    template <class T, std::size_t N>
+    inline batch<T, N> haddp(const batch<T, N>* row)
+    {
+        batch<T, N> result;
+        for (std::size_t i = 0; i < N; ++i)
+        {
+            for (std::size_t j = 0; j < N; ++j)
+            {
+                result[i] += row[i][j];
+            }
+        }
+        return result;
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> select(const batch_bool<T, N>& cond, const batch<T, N>& a, const batch<T, N>& b)
+    {
+        EXPR_MACRO(cond[i] ? a[i] : b[i]);
+    }
+
+    template <class T, std::size_t N>
+    inline batch_bool<T, N> is_nan(const batch<T, N>& x)
+    {
+        batch_bool<T, N> result;
+        for (std::size_t i = 0; i < N; ++i)
+        {
+            result[i] = std::isnan(x[i]);
+        }
+        return result;
+    }
+
+    // rounding
+
+    template <class T, std::size_t N>
+    batch<typename detail::get_int_type<T>::signed_type, N> to_int(const batch<T, N>& x)
+    {
+        using int_type = typename detail::get_int_type<T>::signed_type;
+        using result_type = batch<int_type, N>;
+        result_type result;
+        for (std::size_t i = 0; i < N; ++i)
+        {
+            result[i] = static_cast<int_type>(x[i]);
+        }
+        return result;
+    }
+
+    template <class T, std::size_t N>
+    batch<typename detail::get_float_type<T>::type, N> to_float(const batch<T, N>& x)
+    {
+        using float_type = typename detail::get_float_type<T>::type;
+        using result_type = batch<float_type, N>;
+        result_type result;
+        for (std::size_t i = 0; i < N; ++i)
+        {
+            result[i] = static_cast<float_type>(x[i]);
+        }
+        return result;
+    }
+
+    // template <class T, std::size_t N>
+    // batch<T, N> trunc(const batch<T, N>& x)
+    // {
+    //     EXPR_MACRO(std::trunc(x[i]));
+    // }
+
+    // *
+    //  * Rounds the scalars in \c x to integer values (in floating point format), using
+    //  * the current rounding mode.
+    //  * @param x batch of flaoting point values.
+    //  * @return the batch of nearest integer values.
+     
+    // template <class T, std::size_t N>
+    // batch<T, N> nearbyint(const batch<T, N>& x);
+
+
+}
+
+#endif

--- a/include/xsimd/types/xsimd_sse_conversion.hpp
+++ b/include/xsimd/types/xsimd_sse_conversion.hpp
@@ -106,17 +106,57 @@ namespace xsimd
      * bitwise cast functions implementation *
      *****************************************/
 
+    namespace detail
+    {
+        template <>
+        struct batch_caster<float, int32_t, 4>
+        {
+            batch<int32_t, 4> bitwise(const batch<float, 4>& x)
+            {
+                return _mm_castps_si128(x);
+            }
+        };
+
+        template <>
+        struct batch_caster<int32_t, float, 4>
+        {
+            batch<float, 4> bitwise(const batch<int32_t, 4>& x)
+            {
+                return _mm_castsi128_ps(x);
+            }
+        };
+
+        template <>
+        struct batch_caster<int64_t, double, 2>
+        {
+            batch<double, 2> bitwise(const batch<int64_t, 2>& x)
+            {
+                return _mm_castsi128_pd(x);
+            }
+        };
+
+        template <>
+        struct batch_caster<double, int64_t, 2>
+        {
+            batch<int64_t, 2> bitwise(const batch<double, 2>& x)
+            {
+                return _mm_castpd_si128(x);
+            }
+        };
+    }
+
+
     template <>
     inline batch<double, 2> bitwise_cast(const batch<float, 4>& x)
     {
         return _mm_castps_pd(x);
     }
 
-    template <>
-    inline batch<int32_t, 4> bitwise_cast(const batch<float, 4>& x)
-    {
-        return _mm_castps_si128(x);
-    }
+    // template <>
+    // inline batch<int32_t, 4> bitwise_cast(const batch<float, 4>& x)
+    // {
+    //     return _mm_castps_si128(x);
+    // }
 
     template <>
     inline batch<int64_t, 2> bitwise_cast(const batch<float, 4>& x)
@@ -136,17 +176,17 @@ namespace xsimd
         return _mm_castpd_si128(x);
     }
 
-    template <>
-    inline batch<int64_t, 2> bitwise_cast(const batch<double, 2>& x)
-    {
-        return _mm_castpd_si128(x);
-    }
+    // template <>
+    // inline batch<int64_t, 2> bitwise_cast(const batch<double, 2>& x)
+    // {
+    //     return _mm_castpd_si128(x);
+    // }
 
-    template <>
-    inline batch<float, 4> bitwise_cast(const batch<int32_t, 4>& x)
-    {
-        return _mm_castsi128_ps(x);
-    }
+    // template <>
+    // inline batch<float, 4> bitwise_cast(const batch<int32_t, 4>& x)
+    // {
+    //     return _mm_castsi128_ps(x);
+    // }
 
     template <>
     inline batch<double, 2> bitwise_cast(const batch<int32_t, 4>& x)
@@ -160,11 +200,11 @@ namespace xsimd
         return _mm_castsi128_ps(x);
     }
 
-    template <>
-    inline batch<double, 2> bitwise_cast(const batch<int64_t, 2>& x)
-    {
-        return _mm_castsi128_pd(x);
-    }
+    // template <>
+    // inline batch<double, 2> bitwise_cast(const batch<int64_t, 2>& x)
+    // {
+    //     return _mm_castsi128_pd(x);
+    // }
 }
 
 #endif

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -127,6 +127,8 @@ namespace xsimd
     batch_bool<int64_t, 2> operator!=(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
     batch_bool<int64_t, 2> operator<(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
     batch_bool<int64_t, 2> operator<=(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
+    batch_bool<int64_t, 2> operator>(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
+    batch_bool<int64_t, 2> operator>=(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
 
     batch<int64_t, 2> operator&(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
     batch<int64_t, 2> operator|(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);

--- a/include/xsimd/xsimd.hpp
+++ b/include/xsimd/xsimd.hpp
@@ -357,29 +357,29 @@ namespace xsimd
 
 #if defined(XSIMD_X86_INSTR_SET_AVAILABLE)
 
-    template <>
-    inline void prefetch<int32_t>(const int32_t* address)
-    {
-        _mm_prefetch(reinterpret_cast<const char*>(address), _MM_HINT_T0);
-    }
+    // template <>
+    // inline void prefetch<int32_t>(const int32_t* address)
+    // {
+    //     _mm_prefetch(reinterpret_cast<const char*>(address), _MM_HINT_T0);
+    // }
 
-    template <>
-    inline void prefetch<int64_t>(const int64_t* address)
-    {
-        _mm_prefetch(reinterpret_cast<const char*>(address), _MM_HINT_T0);
-    }
+    // template <>
+    // inline void prefetch<int64_t>(const int64_t* address)
+    // {
+    //     _mm_prefetch(reinterpret_cast<const char*>(address), _MM_HINT_T0);
+    // }
 
-    template <>
-    inline void prefetch<float>(const float* address)
-    {
-        _mm_prefetch(reinterpret_cast<const char*>(address), _MM_HINT_T0);
-    }
+    // template <>
+    // inline void prefetch<float>(const float* address)
+    // {
+    //     _mm_prefetch(reinterpret_cast<const char*>(address), _MM_HINT_T0);
+    // }
 
-    template <>
-    inline void prefetch<double>(const double* address)
-    {
-        _mm_prefetch(reinterpret_cast<const char*>(address), _MM_HINT_T0);
-    }
+    // template <>
+    // inline void prefetch<double>(const double* address)
+    // {
+    //     _mm_prefetch(reinterpret_cast<const char*>(address), _MM_HINT_T0);
+    // }
 
 #endif
 


### PR DESCRIPTION
The shim type can be used for all batch sizes and types, enabling also a scalar version of our algorithms.