### PR TITLE
Cleaned up version of the fallback batch type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,16 @@ add_library(xsimd INTERFACE)
 target_include_directories(xsimd INTERFACE $<BUILD_INTERFACE:${XSIMD_INCLUDE_DIR}>
                                            $<INSTALL_INTERFACE:include>)
 
+OPTION(ENABLE_FALLBACK "build tests/benchmarks with fallback implementation" OFF)
 OPTION(BUILD_TESTS "xsimd test suite" ON)
 OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     set(BUILD_TESTS ON)
+endif()
+
+if(ENABLE_FALLBACK)
+    add_definitions(-DXSIMD_ENABLE_FALLBACK=1)
 endif()
 
 if(BUILD_TESTS)

--- a/benchmark/xsimd_benchmark.hpp
+++ b/benchmark/xsimd_benchmark.hpp
@@ -24,6 +24,8 @@ namespace xsimd
     template <> inline std::string batch_name<batch<double, 2>>() { return "sse/neon double"; }
     template <> inline std::string batch_name<batch<float, 8>>() { return "avx float"; }
     template <> inline std::string batch_name<batch<double, 4>>() { return "avx double"; }
+    template <> inline std::string batch_name<batch<float, 7>>() { return "fallback float"; }
+    template <> inline std::string batch_name<batch<double, 3>>() { return "fallback double"; }
 
     using duration_type = std::chrono::duration<double, std::milli>;
 
@@ -108,7 +110,7 @@ namespace xsimd
         for (std::size_t count = 0; count < number; ++count)
         {
             auto start = std::chrono::steady_clock::now();
-            for (std::size_t i = 0; i < s; i += B::size)
+            for (std::size_t i = 0; i <= (s - B::size); i += B::size)
             {
                 B blhs(&lhs[i], aligned_mode());
                 B bres = f(blhs);
@@ -130,7 +132,7 @@ namespace xsimd
         for (std::size_t count = 0; count < number; ++count)
         {
             auto start = std::chrono::steady_clock::now();
-            for (std::size_t i = 0; i < s; i += inc)
+            for (std::size_t i = 0; i <= (s - inc); i += inc)
             {
                 size_t j = i + B::size;
                 size_t k = j + B::size;
@@ -161,7 +163,7 @@ namespace xsimd
         for (std::size_t count = 0; count < number; ++count)
         {
             auto start = std::chrono::steady_clock::now();
-            for (std::size_t i = 0; i < s; i += B::size)
+            for (std::size_t i = 0; i <= (s - B::size); i += B::size)
             {
                 B blhs(&lhs[i], aligned_mode()), brhs(&rhs[i], aligned_mode());
                 B bres = f(blhs, brhs);
@@ -183,7 +185,7 @@ namespace xsimd
         for (std::size_t count = 0; count < number; ++count)
         {
             auto start = std::chrono::steady_clock::now();
-            for (std::size_t i = 0; i < s; i += inc)
+            for (std::size_t i = 0; i <= (s - inc); i += inc)
             {
                 size_t j = i + B::size;
                 size_t k = j + B::size;
@@ -251,6 +253,10 @@ namespace xsimd
         duration_type t_double_neon = benchmark_simd<batch<double, 2>>(f, d_lhs, d_res, iter);
         duration_type t_double_neon_u = benchmark_simd_unrolled<batch<double, 2>>(f, d_lhs, d_res, iter);
 #endif
+        duration_type t_float_fallback = benchmark_simd<batch<float, 7>>(f, f_lhs, f_res, iter);
+        duration_type t_float_fallback_u = benchmark_simd_unrolled<batch<float, 7>>(f, f_lhs, f_res, iter);
+        duration_type t_double_fallback = benchmark_simd<batch<double, 3>>(f, d_lhs, d_res, iter);
+        duration_type t_double_fallback_u = benchmark_simd_unrolled<batch<double, 3>>(f, d_lhs, d_res, iter);
 
         out << "============================" << std::endl;
         out << f.name() << std::endl;
@@ -267,6 +273,8 @@ namespace xsimd
         out << "neon float     : " << t_float_neon.count() << "ms" << std::endl;
         out << "neon float unr : " << t_float_neon_u.count() << "ms" << std::endl;
 #endif
+        out << "flbk float     : " << t_float_fallback.count() << "ms" << std::endl;
+        out << "flbk float unr : " << t_float_fallback_u.count() << "ms" << std::endl;
         out << "scalar double  : " << t_double_scalar.count() << "ms" << std::endl;
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
         out << "sse double     : " << t_double_sse.count() << "ms" << std::endl;
@@ -280,6 +288,8 @@ namespace xsimd
         out << "neon double    : " << t_double_neon.count() << "ms" << std::endl;
         out << "neon double unr: " << t_double_neon_u.count() << "ms" << std::endl;
 #endif
+        out << "flbk double    : " << t_double_fallback.count() << "ms" << std::endl;
+        out << "flbk double unr: " << t_double_fallback_u.count() << "ms" << std::endl;
         out << "============================" << std::endl;
     }
 
@@ -316,6 +326,10 @@ namespace xsimd
         duration_type t_double_neon = benchmark_simd<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
         duration_type t_double_neon_u = benchmark_simd_unrolled<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
 #endif
+        duration_type t_float_fallback = benchmark_simd<batch<float, 7>>(f, f_lhs, f_rhs, f_res, iter);
+        duration_type t_float_fallback_u = benchmark_simd_unrolled<batch<float, 7>>(f, f_lhs, f_rhs, f_res, iter);
+        duration_type t_double_fallback = benchmark_simd<batch<double, 3>>(f, d_lhs, d_rhs, d_res, iter);
+        duration_type t_double_fallback_u = benchmark_simd_unrolled<batch<double, 3>>(f, d_lhs, d_rhs, d_res, iter);
 
         out << "============================" << std::endl;
         out << f.name() << std::endl;
@@ -332,6 +346,8 @@ namespace xsimd
         out << "neon float     : " << t_float_neon.count() << "ms" << std::endl;
         out << "neon float unr : " << t_float_neon_u.count() << "ms" << std::endl;
 #endif
+        out << "flbk float     : " << t_float_fallback.count() << "ms" << std::endl;
+        out << "flbk float unr : " << t_float_fallback_u.count() << "ms" << std::endl;
         out << "scalar double  : " << t_double_scalar.count() << "ms" << std::endl;
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
         out << "sse double     : " << t_double_sse.count() << "ms" << std::endl;
@@ -345,6 +361,8 @@ namespace xsimd
         out << "neon double    : " << t_double_neon.count() << "ms" << std::endl;
         out << "neon double unr: " << t_double_neon_u.count() << "ms" << std::endl;
 #endif
+        out << "flbk double    : " << t_double_fallback.count() << "ms" << std::endl;
+        out << "flbk double unr: " << t_double_fallback_u.count() << "ms" << std::endl;
         out << "============================" << std::endl;
     }
 

--- a/benchmark/xsimd_benchmark.hpp
+++ b/benchmark/xsimd_benchmark.hpp
@@ -253,10 +253,12 @@ namespace xsimd
         duration_type t_double_neon = benchmark_simd<batch<double, 2>>(f, d_lhs, d_res, iter);
         duration_type t_double_neon_u = benchmark_simd_unrolled<batch<double, 2>>(f, d_lhs, d_res, iter);
 #endif
+#if defined(XSIMD_ENABLE_FALLBACK)
         duration_type t_float_fallback = benchmark_simd<batch<float, 7>>(f, f_lhs, f_res, iter);
         duration_type t_float_fallback_u = benchmark_simd_unrolled<batch<float, 7>>(f, f_lhs, f_res, iter);
         duration_type t_double_fallback = benchmark_simd<batch<double, 3>>(f, d_lhs, d_res, iter);
         duration_type t_double_fallback_u = benchmark_simd_unrolled<batch<double, 3>>(f, d_lhs, d_res, iter);
+#endif
 
         out << "============================" << std::endl;
         out << f.name() << std::endl;
@@ -273,8 +275,10 @@ namespace xsimd
         out << "neon float     : " << t_float_neon.count() << "ms" << std::endl;
         out << "neon float unr : " << t_float_neon_u.count() << "ms" << std::endl;
 #endif
+#if defined(XSIMD_ENABLE_FALLBACK)
         out << "flbk float     : " << t_float_fallback.count() << "ms" << std::endl;
         out << "flbk float unr : " << t_float_fallback_u.count() << "ms" << std::endl;
+#endif
         out << "scalar double  : " << t_double_scalar.count() << "ms" << std::endl;
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
         out << "sse double     : " << t_double_sse.count() << "ms" << std::endl;
@@ -288,8 +292,10 @@ namespace xsimd
         out << "neon double    : " << t_double_neon.count() << "ms" << std::endl;
         out << "neon double unr: " << t_double_neon_u.count() << "ms" << std::endl;
 #endif
+#if defined(XSIMD_ENABLE_FALLBACK)
         out << "flbk double    : " << t_double_fallback.count() << "ms" << std::endl;
         out << "flbk double unr: " << t_double_fallback_u.count() << "ms" << std::endl;
+#endif
         out << "============================" << std::endl;
     }
 
@@ -326,10 +332,12 @@ namespace xsimd
         duration_type t_double_neon = benchmark_simd<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
         duration_type t_double_neon_u = benchmark_simd_unrolled<batch<double, 2>>(f, d_lhs, d_rhs, d_res, iter);
 #endif
+#if defined(XSIMD_ENABLE_FALLBACK)
         duration_type t_float_fallback = benchmark_simd<batch<float, 7>>(f, f_lhs, f_rhs, f_res, iter);
         duration_type t_float_fallback_u = benchmark_simd_unrolled<batch<float, 7>>(f, f_lhs, f_rhs, f_res, iter);
         duration_type t_double_fallback = benchmark_simd<batch<double, 3>>(f, d_lhs, d_rhs, d_res, iter);
         duration_type t_double_fallback_u = benchmark_simd_unrolled<batch<double, 3>>(f, d_lhs, d_rhs, d_res, iter);
+#endif
 
         out << "============================" << std::endl;
         out << f.name() << std::endl;
@@ -346,8 +354,10 @@ namespace xsimd
         out << "neon float     : " << t_float_neon.count() << "ms" << std::endl;
         out << "neon float unr : " << t_float_neon_u.count() << "ms" << std::endl;
 #endif
+#if defined(XSIMD_ENABLE_FALLBACK)
         out << "flbk float     : " << t_float_fallback.count() << "ms" << std::endl;
         out << "flbk float unr : " << t_float_fallback_u.count() << "ms" << std::endl;
+#endif
         out << "scalar double  : " << t_double_scalar.count() << "ms" << std::endl;
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
         out << "sse double     : " << t_double_sse.count() << "ms" << std::endl;
@@ -361,8 +371,10 @@ namespace xsimd
         out << "neon double    : " << t_double_neon.count() << "ms" << std::endl;
         out << "neon double unr: " << t_double_neon_u.count() << "ms" << std::endl;
 #endif
+#if defined(XSIMD_ENABLE_FALLBACK)
         out << "flbk double    : " << t_double_fallback.count() << "ms" << std::endl;
         out << "flbk double unr: " << t_double_fallback_u.count() << "ms" << std::endl;
+#endif
         out << "============================" << std::endl;
     }
 

--- a/docs/source/api/available_wrappers.rst
+++ b/docs/source/api/available_wrappers.rst
@@ -29,9 +29,21 @@
 Available wrappers
 ==================
 
-The :ref:`batch <xsimd-batch-ref>` and :ref:`batch_bool <xsimd-batch-bool-ref>` generic template classes are not implemented,
-only full specializations of these templates are available depending on the instruction set macros defined according to
-the instruction sets provided by the compiler.
+The :ref:`batch <xsimd-batch-ref>` and :ref:`batch_bool <xsimd-batch-bool-ref>` generic template classes are not implemented
+by default, only full specializations of these templates are available depending on the instruction set macros defined
+according to the instruction sets provided by the compiler.
+
+Fallback implementation
+-----------------------
+
+You may optionally enable a fallback implementation, which translates batch and batch_bool variants that do not exist in
+hardware into scalar loops. This is done by setting the XSIMD_ENABLE_FALLBACK preprocessor flag before including any xsimd
+header.
+
+This scalar fallback enables you to test the correctness of your computations without having matching hardware available, but
+you should be aware that it is only intended for use in validation scenarios. It has generally speaking not been tuned for
+performance, and its run-time characteristics may vary enormously from one compiler to another. Enabling it in
+performance-conscious production code is therefore strongly discouraged.
 
 x86 architecture
 ----------------

--- a/include/xsimd/math/xsimd_rounding.hpp
+++ b/include/xsimd/math/xsimd_rounding.hpp
@@ -317,10 +317,11 @@ namespace xsimd
     }
 #endif
 
-    /**************************
-     * Generic implementation *
-     **************************/
+    /***************************
+     * Fallback implementation *
+     ***************************/
 
+#if defined(XSIMD_ENABLE_FALLBACK)
     template <class T, std::size_t N>
     inline batch<T, N> ceil(const batch<T, N>& x)
     {
@@ -344,6 +345,7 @@ namespace xsimd
     {
         XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::nearbyint, x)
     }
+#endif
 
     /**************************
      * Generic implementation *

--- a/include/xsimd/math/xsimd_rounding.hpp
+++ b/include/xsimd/math/xsimd_rounding.hpp
@@ -130,8 +130,9 @@ namespace xsimd
 
 #elif (XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION) || (XSIMD_ARM_INSTR_SET == XSIMD_ARM7_NEON_VERSION)
 
+    // NOTE: Renamed to avoid collision with the fallback implementation
     template <class T, std::size_t N>
-    inline batch<T, N> ceil(const batch<T, N>& x)
+    inline batch<T, N> ceil_impl(const batch<T, N>& x)
     {
         using btype = batch<T, N>;
         btype tx = trunc(x);
@@ -139,7 +140,7 @@ namespace xsimd
     }
 
     template <class T, std::size_t N>
-    inline batch<T, N> floor(const batch<T, N>& x)
+    inline batch<T, N> floor_impl(const batch<T, N>& x)
     {
         using btype = batch<T, N>;
         btype tx = trunc(x);
@@ -147,7 +148,7 @@ namespace xsimd
     }
 
     template <class T, std::size_t N>
-    inline batch<T, N> nearbyint(const batch<T, N>& x)
+    inline batch<T, N> nearbyint_impl(const batch<T, N>& x)
     {
         using btype = batch<T, N>;
         btype s = bitofsign(x);
@@ -158,6 +159,24 @@ namespace xsimd
     }
 
     template <>
+    inline batch<float, 4> ceil(const batch<float, 4>& x)
+    {
+        return ceil_impl(x);
+    }
+
+    template <>
+    inline batch<float, 4> floor(const batch<float, 4>& x)
+    {
+        return floor_impl(x);
+    }
+
+    template <>
+    inline batch<float, 4> nearbyint(const batch<float, 4>& x)
+    {
+        return nearbyint_impl(x);
+    }
+
+    template <>
     inline batch<float, 4> trunc(const batch<float, 4>& x)
     {
         using btype = batch<float, 4>;
@@ -165,6 +184,24 @@ namespace xsimd
     }
 
 #if (XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION)
+    template <>
+    inline batch<double, 2> ceil(const batch<double, 2>& x)
+    {
+        return ceil_impl(x);
+    }
+
+    template <>
+    inline batch<double, 2> floor(const batch<double, 2>& x)
+    {
+        return floor_impl(x);
+    }
+
+    template <>
+    inline batch<double, 2> nearbyint(const batch<double, 2>& x)
+    {
+        return nearbyint_impl(x);
+    }
+
     template <>
     inline batch<double, 2> trunc(const batch<double, 2>& x)
     {
@@ -279,6 +316,34 @@ namespace xsimd
         return vrndxq_f64(x);
     }
 #endif
+
+    /**************************
+     * Generic implementation *
+     **************************/
+
+    template <class T, std::size_t N>
+    inline batch<T, N> ceil(const batch<T, N>& x)
+    {
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::ceil, x)
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> floor(const batch<T, N>& x)
+    {
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::floor, x)
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> trunc(const batch<T, N>& x)
+    {
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::trunc, x)
+    }
+
+    template <class T, std::size_t N>
+    inline batch<T, N> nearbyint(const batch<T, N>& x)
+    {
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::nearbyint, x)
+    }
 
     /**************************
      * Generic implementation *

--- a/include/xsimd/types/xsimd_avx_conversion.hpp
+++ b/include/xsimd/types/xsimd_avx_conversion.hpp
@@ -36,22 +36,6 @@ namespace xsimd
     batch_bool<float, 8> bool_cast(const batch_bool<int32_t, 8>& x);
     batch_bool<double, 4> bool_cast(const batch_bool<int64_t, 4>& x);
 
-    /**************************
-     * bitwise cast functions *
-     **************************/
-
-    template <class B>
-    B bitwise_cast(const batch<float, 8>& x);
-
-    template <class B>
-    B bitwise_cast(const batch<double, 4>& x);
-
-    template <class B>
-    B bitwise_cast(const batch<int32_t, 8>& x);
-
-    template <class B>
-    B bitwise_cast(const batch<int64_t, 4>& x);
-
     /***************************************
      * conversion functions implementation *
      ***************************************/
@@ -116,65 +100,45 @@ namespace xsimd
      * bitwise cast functions implementation *
      *****************************************/
 
-    template <>
-    inline batch<double, 4> bitwise_cast(const batch<float, 8>& x)
-    {
-        return _mm256_castps_pd(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8,
+                                 double, 4,
+                                 _mm256_castps_pd)
 
-    template <>
-    inline batch<int32_t, 8> bitwise_cast(const batch<float, 8>& x)
-    {
-        return _mm256_castps_si256(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8,
+                                 int32_t, 8,
+                                 _mm256_castps_si256)
 
-    template <>
-    inline batch<int64_t, 4> bitwise_cast(const batch<float, 8>& x)
-    {
-        return _mm256_castps_si256(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8,
+                                 int64_t, 4,
+                                 _mm256_castps_si256)
 
-    template <>
-    inline batch<float, 8> bitwise_cast(const batch<double, 4>& x)
-    {
-        return _mm256_castpd_ps(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4,
+                                 float, 8,
+                                 _mm256_castpd_ps)
 
-    template <>
-    inline batch<int32_t, 8> bitwise_cast(const batch<double, 4>& x)
-    {
-        return _mm256_castpd_si256(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4,
+                                 int32_t, 8,
+                                 _mm256_castpd_si256)
 
-    template <>
-    inline batch<int64_t, 4> bitwise_cast(const batch<double, 4>& x)
-    {
-        return _mm256_castpd_si256(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4,
+                                 int64_t, 4,
+                                 _mm256_castpd_si256)
 
-    template <>
-    inline batch<float, 8> bitwise_cast(const batch<int32_t, 8>& x)
-    {
-        return _mm256_castsi256_ps(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 8,
+                                 float, 8,
+                                 _mm256_castsi256_ps)
 
-    template <>
-    inline batch<double, 4> bitwise_cast(const batch<int32_t, 8>& x)
-    {
-        return _mm256_castsi256_pd(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 8,
+                                 double, 4,
+                                 _mm256_castsi256_pd)
 
-    template <>
-    inline batch<float, 8> bitwise_cast(const batch<int64_t, 4>& x)
-    {
-        return _mm256_castsi256_ps(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 4,
+                                 float, 8,
+                                 _mm256_castsi256_ps)
 
-    template <>
-    inline batch<double, 4> bitwise_cast(const batch<int64_t, 4>& x)
-    {
-        return _mm256_castsi256_pd(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 4,
+                                 double, 4,
+                                 _mm256_castsi256_pd)
 }
 
 #endif

--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -40,6 +40,8 @@ namespace xsimd
 
         operator __m256d() const;
 
+        bool operator[](std::size_t index) const;
+
     private:
 
         __m256d m_value;
@@ -190,6 +192,13 @@ namespace xsimd
     inline batch_bool<double, 4>::operator __m256d() const
     {
         return m_value;
+    }
+
+    inline bool batch_bool<double, 4>::operator[](std::size_t index) const
+    {
+        alignas(32) double x[4];
+        _mm256_store_pd(x, m_value);
+        return static_cast<bool>(x[index & 3]);
     }
 
     inline batch_bool<double, 4> operator&(const batch_bool<double, 4>& lhs, const batch_bool<double, 4>& rhs)

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -41,6 +41,8 @@ namespace xsimd
 
         operator __m256() const;
 
+        bool operator[](std::size_t index) const;
+
     private:
 
         __m256 m_value;
@@ -192,6 +194,13 @@ namespace xsimd
     inline batch_bool<float, 8>::operator __m256() const
     {
         return m_value;
+    }
+
+    inline bool batch_bool<float, 8>::operator[](std::size_t index) const
+    {
+        alignas(32) float x[8];
+        _mm256_store_ps(x, m_value);
+        return static_cast<bool>(x[index & 7]);
     }
 
     inline batch_bool<float, 8> operator&(const batch_bool<float, 8>& lhs, const batch_bool<float, 8>& rhs)

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -42,6 +42,8 @@ namespace xsimd
 
         operator __m256i() const;
 
+        bool operator[](std::size_t index) const;
+
     private:
 
         __m256i m_value;
@@ -203,6 +205,13 @@ namespace xsimd
     inline batch_bool<int32_t, 8>::operator __m256i() const
     {
         return m_value;
+    }
+
+    inline bool batch_bool<int32_t, 8>::operator[](std::size_t index) const
+    {
+        alignas(32) int32_t x[8];
+        _mm256_store_si256((__m256i*)x, m_value);
+        return static_cast<bool>(x[index & 7]);
     }
 
     inline batch_bool<int32_t, 8> operator&(const batch_bool<int32_t, 8>& lhs, const batch_bool<int32_t, 8>& rhs)

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -42,6 +42,8 @@ namespace xsimd
 
         operator __m256i() const;
 
+        bool operator[](std::size_t index) const;
+
     private:
 
         __m256i m_value;
@@ -204,6 +206,13 @@ namespace xsimd
     inline batch_bool<int64_t, 4>::operator __m256i() const
     {
         return m_value;
+    }
+
+    inline bool batch_bool<int64_t, 4>::operator[](std::size_t index) const
+    {
+        alignas(32) int64_t x[4];
+        _mm256_store_si256((__m256i*)x, m_value);
+        return static_cast<bool>(x[index & 3]);
     }
 
     inline batch_bool<int64_t, 4> operator&(const batch_bool<int64_t, 4>& lhs, const batch_bool<int64_t, 4>& rhs)

--- a/include/xsimd/types/xsimd_base.hpp
+++ b/include/xsimd/types/xsimd_base.hpp
@@ -207,6 +207,39 @@ namespace xsimd
     template <class T, std::size_t N>
     batch<T, N> operator>>(const batch<T, N>& lhs, const batch<T, N>& rhs);
 
+    /**************************
+     * bitwise cast functions *
+     **************************/
+
+    // Provides a reinterpret_case from batch<T_in, N_in> to batch<T_out, N_out>
+    template <class B_in, class B_out>
+    struct bitwise_cast_impl;
+
+    // Shorthand for defining an intrinsic-based bitwise_cast implementation
+    #define XSIMD_BITWISE_CAST_INTRINSIC(T_IN, N_IN, T_OUT, N_OUT, INTRINSIC)  \
+        template <>                                                            \
+        struct bitwise_cast_impl<batch<T_IN, N_IN>, batch<T_OUT, N_OUT>>       \
+        {                                                                      \
+            static inline batch<T_OUT, N_OUT> run(const batch<T_IN, N_IN>& x)  \
+            {                                                                  \
+                return INTRINSIC(x);                                           \
+            }                                                                  \
+        };
+
+
+    // Backwards-compatible interface to bitwise_cast_impl
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<float, N>& x);
+
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<double, N>& x);
+
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<int32_t, N>& x);
+
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<int64_t, N>& x);
+
     /**********************************
      * simd_batch_bool implementation *
      **********************************/
@@ -859,6 +892,34 @@ namespace xsimd
     inline batch<T, N> operator>>(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
         GENERIC_OPERATOR_IMPLEMENTATION(>>);
+    }
+
+    /*****************************************
+     * bitwise cast functions implementation *
+     *****************************************/
+
+    template <class B, std::size_t N>
+    B bitwise_cast(const batch<float, N>& x)
+    {
+        return bitwise_cast_impl<batch<float, N>, B>::run(x);
+    }
+
+    template <class B, std::size_t N>
+    B bitwise_cast(const batch<double, N>& x)
+    {
+        return bitwise_cast_impl<batch<double, N>, B>::run(x);
+    }
+
+    template <class B, std::size_t N>
+    B bitwise_cast(const batch<int32_t, N>& x)
+    {
+        return bitwise_cast_impl<batch<int32_t, N>, B>::run(x);
+    }
+
+    template <class B, std::size_t N>
+    B bitwise_cast(const batch<int64_t, N>& x)
+    {
+        return bitwise_cast_impl<batch<int64_t, N>, B>::run(x);
     }
 }
 

--- a/include/xsimd/types/xsimd_base.hpp
+++ b/include/xsimd/types/xsimd_base.hpp
@@ -91,6 +91,9 @@ namespace xsimd
     template <class X>
     X operator!(const simd_batch_bool<X>& rhs);
 
+    template <class X>
+    std::ostream& operator<<(std::ostream& out, const simd_batch_bool<X>& rhs);
+
     /**************
      * simd_batch *
      **************/
@@ -422,6 +425,26 @@ namespace xsimd
     inline X operator!(const simd_batch_bool<X>& rhs)
     {
         return rhs() == X(false);
+    }
+
+    /**
+     * Insert the batch \c rhs into the stream \c out.
+     * @tparam X the actual type of batch.
+     * @param out the output stream.
+     * @param rhs the batch to output.
+     * @return the output stream.
+     */
+    template <class X>
+    inline std::ostream& operator<<(std::ostream& out, const simd_batch_bool<X>& rhs)
+    {
+        out << '(';
+        std::size_t s = simd_batch_bool<X>::size;
+        for (std::size_t i = 0; i < s - 1; ++i)
+        {
+            out << (rhs()[i] ? 'T' : 'F') << ", ";
+        }
+        out << (rhs()[s - 1] ? 'T' : 'F') << ')';
+        return out;
     }
 
     /*****************************

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -398,50 +398,50 @@ namespace xsimd
     }  \
     return result;
 
-#define XSIMD_FALLBACK_UNARY_OP(RESULT_TYPE, OPERATOR)  \
-    XSIMD_FALLBACK_MAPPING_LOOP(RESULT_TYPE, (OPERATOR rhs[i]))
+#define XSIMD_FALLBACK_UNARY_OP(RESULT_TYPE, OPERATOR, X)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(RESULT_TYPE, (OPERATOR X[i]))
 
-#define XSIMD_FALLBACK_BINARY_OP(RESULT_TYPE, OPERATOR)  \
-    XSIMD_FALLBACK_MAPPING_LOOP(RESULT_TYPE, (lhs[i] OPERATOR rhs[i]))
+#define XSIMD_FALLBACK_BINARY_OP(RESULT_TYPE, OPERATOR, X, Y)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(RESULT_TYPE, (X[i] OPERATOR Y[i]))
 
-#define XSIMD_FALLBACK_BATCH_BITWISE_UNARY_OP(OPERATOR)  \
+#define XSIMD_FALLBACK_BATCH_BITWISE_UNARY_OP(OPERATOR, X)  \
     XSIMD_FALLBACK_MAPPING_LOOP(  \
         batch,  \
         detail::from_unsigned<T>::run(  \
-            OPERATOR detail::to_unsigned<T>::run(rhs[i])  \
+            OPERATOR detail::to_unsigned<T>::run(X[i])  \
         )  \
     )
 
-#define XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(OPERATOR)  \
+#define XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(OPERATOR, X, Y)  \
     XSIMD_FALLBACK_MAPPING_LOOP(  \
         batch,  \
         detail::from_unsigned<T>::run(  \
-            detail::to_unsigned<T>::run(lhs[i])  \
+            detail::to_unsigned<T>::run(X[i])  \
             OPERATOR  \
-            detail::to_unsigned<T>::run(rhs[i])  \
+            detail::to_unsigned<T>::run(Y[i])  \
         )  \
     )
 
-#define XSIMD_FALLBACK_BATCH_UNARY_FUNC(FUNCTION)  \
-    XSIMD_FALLBACK_MAPPING_LOOP(batch, FUNCTION(rhs[i]))
+#define XSIMD_FALLBACK_BATCH_UNARY_FUNC(FUNCTION, X)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(batch, FUNCTION(X[i]))
 
-#define XSIMD_FALLBACK_BATCH_BINARY_FUNC(FUNCTION)  \
-    XSIMD_FALLBACK_MAPPING_LOOP(batch, FUNCTION(lhs[i], rhs[i]))
+#define XSIMD_FALLBACK_BATCH_BINARY_FUNC(FUNCTION, X, Y)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(batch, FUNCTION(X[i], Y[i]))
 
-#define XSIMD_FALLBACK_BATCH_TERNARY_FUNC(FUNCTION)  \
-    XSIMD_FALLBACK_MAPPING_LOOP(batch, FUNCTION(x[i], y[i], z[i]))
+#define XSIMD_FALLBACK_BATCH_TERNARY_FUNC(FUNCTION, X, Y, Z)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(batch, FUNCTION(X[i], Y[i], Z[i]))
 
 // NOTE: Static casting a vector is static casting every element
-#define XSIMD_FALLBACK_BATCH_STATIC_CAST(T_OUT)  \
+#define XSIMD_FALLBACK_BATCH_STATIC_CAST(T_OUT, X)  \
     batch<T_OUT, N> result;  \
     for(std::size_t i = 0; i < N; ++i) {  \
-        result[i] = static_cast<T_OUT>(x[i]);  \
+        result[i] = static_cast<T_OUT>(X[i]);  \
     }  \
     return result;
 
 // NOTE: Casting between batch_bools of the same size is actually trivial!
-#define XSIMD_FALLBACK_BOOL_CAST(T_OUT)  \
-    return batch_bool<T_OUT, N>(static_cast<std::array<bool, N>>(x));
+#define XSIMD_FALLBACK_BOOL_CAST(T_OUT, X)  \
+    return batch_bool<T_OUT, N>(static_cast<std::array<bool, N>>(X));
 
     /***********************************
      * batch_bool<T, N> implementation *
@@ -492,25 +492,25 @@ namespace xsimd
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator&(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch_bool, &)
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, &, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator|(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch_bool, |)
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, |, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator^(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch_bool, ^)
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, ^, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator~(const batch_bool<T, N>& rhs)
     {
-        XSIMD_FALLBACK_UNARY_OP(batch_bool, ~)
+        XSIMD_FALLBACK_UNARY_OP(batch_bool, ~, rhs)
     }
 
     template <typename T, std::size_t N>
@@ -522,13 +522,13 @@ namespace xsimd
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator==(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch_bool, ==)
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, ==, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator!=(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch_bool, !=)
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, !=, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
@@ -731,79 +731,79 @@ namespace xsimd
     template <typename T, std::size_t N>
     inline batch<T, N> operator-(const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_UNARY_OP(batch, -)
+        XSIMD_FALLBACK_UNARY_OP(batch, -, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> operator+(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch, +)
+        XSIMD_FALLBACK_BINARY_OP(batch, +, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> operator-(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch, -)
+        XSIMD_FALLBACK_BINARY_OP(batch, -, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> operator*(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch, *)
+        XSIMD_FALLBACK_BINARY_OP(batch, *, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> operator/(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch, /)
+        XSIMD_FALLBACK_BINARY_OP(batch, /, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator==(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch_bool, ==)
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, ==, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator!=(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch_bool, !=)
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, !=, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator<(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch_bool, <)
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, <, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch_bool<T, N> operator<=(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BINARY_OP(batch_bool, <=)
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, <=, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> operator&(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(&)
+        XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(&, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> operator|(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(|)
+        XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(|, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> operator^(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(^)
+        XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(^, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> operator~(const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_BITWISE_UNARY_OP(~)
+        XSIMD_FALLBACK_BATCH_BITWISE_UNARY_OP(~, rhs)
     }
 
     template <typename T, std::size_t N>
@@ -824,49 +824,49 @@ namespace xsimd
     template <typename T, std::size_t N>
     inline batch<T, N> min(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::min)
+        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::min, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> max(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::max)
+        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::max, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> fmin(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::fmin)
+        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::fmin, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> fmax(const batch<T, N>& lhs, const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::fmax)
+        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::fmax, lhs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> abs(const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::abs)
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::abs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> fabs(const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::fabs)
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::fabs, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> sqrt(const batch<T, N>& rhs)
     {
-        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::sqrt)
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::sqrt, rhs)
     }
 
     template <typename T, std::size_t N>
     inline batch<T, N> fma(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z)
     {
-        XSIMD_FALLBACK_BATCH_TERNARY_FUNC(std::fma)
+        XSIMD_FALLBACK_BATCH_TERNARY_FUNC(std::fma, x, y, z)
     }
 
     template <typename T, std::size_t N>
@@ -932,25 +932,25 @@ namespace xsimd
     template <std::size_t N>
     inline batch<int32_t, N> to_int(const batch<float, N>& x)
     {
-        XSIMD_FALLBACK_BATCH_STATIC_CAST(int32_t)
+        XSIMD_FALLBACK_BATCH_STATIC_CAST(int32_t, x)
     }
 
     template <std::size_t N>
     inline batch<int64_t, N> to_int(const batch<double, N>& x)
     {
-        XSIMD_FALLBACK_BATCH_STATIC_CAST(int64_t)
+        XSIMD_FALLBACK_BATCH_STATIC_CAST(int64_t, x)
     }
 
     template <std::size_t N>
     inline batch<float, N> to_float(const batch<int32_t, N>& x)
     {
-        XSIMD_FALLBACK_BATCH_STATIC_CAST(float)
+        XSIMD_FALLBACK_BATCH_STATIC_CAST(float, x)
     }
 
     template <std::size_t N>
     inline batch<double, N> to_float(const batch<int64_t, N>& x)
     {
-        XSIMD_FALLBACK_BATCH_STATIC_CAST(double)
+        XSIMD_FALLBACK_BATCH_STATIC_CAST(double, x)
     }
 
     /**************************
@@ -960,25 +960,25 @@ namespace xsimd
     template <std::size_t N>
     inline batch_bool<int32_t, N> bool_cast(const batch_bool<float, N>& x)
     {
-        XSIMD_FALLBACK_BOOL_CAST(int32_t)
+        XSIMD_FALLBACK_BOOL_CAST(int32_t, x)
     }
 
     template <std::size_t N>
     inline batch_bool<int64_t, N> bool_cast(const batch_bool<double, N>& x)
     {
-        XSIMD_FALLBACK_BOOL_CAST(int64_t)
+        XSIMD_FALLBACK_BOOL_CAST(int64_t, x)
     }
 
     template <std::size_t N>
     inline batch_bool<float, N> bool_cast(const batch_bool<int32_t, N>& x)
     {
-        XSIMD_FALLBACK_BOOL_CAST(float)
+        XSIMD_FALLBACK_BOOL_CAST(float, x)
     }
 
     template <std::size_t N>
     inline batch_bool<double, N> bool_cast(const batch_bool<int64_t, N>& x)
     {
-        XSIMD_FALLBACK_BOOL_CAST(double)
+        XSIMD_FALLBACK_BOOL_CAST(double, x)
     }
 
     /*****************************************

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -118,17 +118,40 @@ namespace xsimd
 
         operator std::array<T, N>() const;
 
-        batch& load_aligned(const T* src);
-        batch& load_unaligned(const T* src);
+        batch& load_aligned(const float* src);
+        batch& load_unaligned(const float* src);
 
-        void store_aligned(T* dst) const;
-        void store_unaligned(T* dst) const;
+        batch& load_aligned(const double* src);
+        batch& load_unaligned(const double* src);
+
+        batch& load_aligned(const int32_t* src);
+        batch& load_unaligned(const int32_t* src);
+
+        batch& load_aligned(const int64_t* src);
+        batch& load_unaligned(const int64_t* src);
+
+        void store_aligned(float* dst) const;
+        void store_unaligned(float* dst) const;
+
+        void store_aligned(double* dst) const;
+        void store_unaligned(double* dst) const;
+
+        void store_aligned(int32_t* dst) const;
+        void store_unaligned(int32_t* dst) const;
+
+        void store_aligned(int64_t* dst) const;
+        void store_unaligned(int64_t* dst) const;
 
         const T& operator[](std::size_t index) const;
         T& operator[](std::size_t index);
 
 
     private:
+
+        template<typename U>
+        batch& load_unaligned_impl(const U* src);
+        template<typename U>
+        void store_unaligned_impl(U* src) const;
 
         std::array<T, N> m_value;
     };
@@ -579,30 +602,99 @@ namespace xsimd
     }
 
     template <typename T, std::size_t N>
-    inline batch<T, N>& batch<T, N>::load_aligned(const T* src)
+    inline batch<T, N>& batch<T, N>::load_aligned(const float* src)
     {
-        return this->load_unaligned(src);
+        return this->load_unaligned_impl(src);
     }
 
     template <typename T, std::size_t N>
-    inline batch<T, N>& batch<T, N>::load_unaligned(const T* src)
+    inline batch<T, N>& batch<T, N>::load_unaligned(const float* src)
     {
-        m_value = detail::array_from_pointer<T, N>(src);
-        return *this;
+        return this->load_unaligned_impl(src);
     }
 
     template <typename T, std::size_t N>
-    inline void batch<T, N>::store_aligned(T* dst) const
+    inline batch<T, N>& batch<T, N>::load_aligned(const double* src)
     {
-        this->store_unaligned(dst);
+        return this->load_unaligned_impl(src);
     }
 
     template <typename T, std::size_t N>
-    inline void batch<T, N>::store_unaligned(T* dst) const
+    inline batch<T, N>& batch<T, N>::load_unaligned(const double* src)
     {
-        for(std::size_t i = 0; i < N; ++i) {
-            dst[i] = m_value[i];
-        }
+        return this->load_unaligned_impl(src);
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::load_aligned(const int32_t* src)
+    {
+        return this->load_unaligned_impl(src);
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::load_unaligned(const int32_t* src)
+    {
+        return this->load_unaligned_impl(src);
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::load_aligned(const int64_t* src)
+    {
+        return this->load_unaligned_impl(src);
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::load_unaligned(const int64_t* src)
+    {
+        return this->load_unaligned_impl(src);
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_aligned(float* dst) const
+    {
+        this->store_unaligned_impl(dst);
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_unaligned(float* dst) const
+    {
+        this->store_unaligned_impl(dst);
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_aligned(double* dst) const
+    {
+        this->store_unaligned_impl(dst);
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_unaligned(double* dst) const
+    {
+        this->store_unaligned_impl(dst);
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_aligned(int32_t* dst) const
+    {
+        this->store_unaligned_impl(dst);
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_unaligned(int32_t* dst) const
+    {
+        this->store_unaligned_impl(dst);
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_aligned(int64_t* dst) const
+    {
+        this->store_unaligned_impl(dst);
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_unaligned(int64_t* dst) const
+    {
+        this->store_unaligned_impl(dst);
     }
 
     template <typename T, std::size_t N>
@@ -615,6 +707,25 @@ namespace xsimd
     inline T& batch<T, N>::operator[](std::size_t index)
     {
         return m_value[index];
+    }
+
+    template <typename T, std::size_t N>
+    template <typename U>
+    inline batch<T, N>& batch<T, N>::load_unaligned_impl(const U* src)
+    {
+        for(std::size_t i = 0; i < N; ++i) {
+            m_value[i] = static_cast<T>(src[i]);
+        }
+        return *this;
+    }
+
+    template <typename T, std::size_t N>
+    template <typename U>
+    inline void batch<T, N>::store_unaligned_impl(U* dst) const
+    {
+        for(std::size_t i = 0; i < N; ++i) {
+            dst[i] = static_cast<U>(m_value[i]);
+        }
     }
 
     template <typename T, std::size_t N>

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -1,0 +1,900 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSIMD_FALLBACK_HPP
+#define XSIMD_FALLBACK_HPP
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <utility>
+
+#include "xsimd_base.hpp"
+
+namespace xsimd
+{
+
+    /***********************************************************
+     * Generic fallback implementation of batch and batch_bool *
+     *                                                         *
+     * Basically, generate a scalar loop and cross fingers:    *
+     * maybe the compiler will autovectorize, maybe not.       *
+     ***********************************************************/
+
+    /********************
+     * batch_bool<T, N> *
+     ********************/
+
+    template <typename T, std::size_t N>
+    struct simd_batch_traits<batch_bool<T, N>>
+    {
+        using value_type = T;
+        static constexpr std::size_t size = N;
+        using batch_type = batch<T, N>;
+        static constexpr std::size_t align = XSIMD_DEFAULT_ALIGNMENT;
+    };
+
+    template <typename T, std::size_t N>
+    class batch_bool : public simd_batch_bool<batch_bool<T, N>>
+    {
+    public:
+
+        batch_bool();
+        explicit batch_bool(bool b);
+
+        // NOTE: Other batch_bool types have a constructor which takes N bools,
+        //       but C++ does not seem to provide a way to do this which is
+        //       both generic over N and compatible with the other batch_bools.
+
+        batch_bool(const std::array<bool, N>& rhs);
+        batch_bool& operator=(const std::array<bool, N>& rhs);
+
+        operator std::array<bool, N>() const;
+
+        const bool& operator[](std::size_t index) const;
+        bool& operator[](std::size_t index);
+
+    private:
+
+        std::array<bool, N> m_value;
+    };
+
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator&(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator|(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator^(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator~(const batch_bool<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch_bool<T, N> bitwise_andnot(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator==(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator!=(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs);
+
+    template <typename T, std::size_t N>
+    bool all(const batch_bool<T, N>& rhs);
+    template <typename T, std::size_t N>
+    bool any(const batch_bool<T, N>& rhs);
+
+    /***************
+     * batch<T, N> *
+     ***************/
+
+    template <typename T, std::size_t N>
+    struct simd_batch_traits<batch<T, N>>
+    {
+        using value_type = T;
+        static constexpr std::size_t size = N;
+        using batch_bool_type = batch_bool<T, N>;
+        static constexpr std::size_t align = XSIMD_DEFAULT_ALIGNMENT;
+    };
+
+    template <typename T, std::size_t N>
+    class batch : public simd_batch<batch<T, N>>
+    {
+    public:
+
+        batch();
+        explicit batch(T f);
+
+        // NOTE: Other batch types have a constructor which takes N scalars, but
+        //       C++ does not seem to provide a way to do this which is both
+        //       generic over N and compatible with the other batch types.
+
+        explicit batch(const T* src);
+        batch(const T* src, aligned_mode);
+        batch(const T* src, unaligned_mode);
+        batch(const std::array<T, N>& rhs);
+        batch& operator=(const std::array<T, N>& rhs);
+
+        operator std::array<T, N>() const;
+
+        batch& load_aligned(const T* src);
+        batch& load_unaligned(const T* src);
+
+        void store_aligned(T* dst) const;
+        void store_unaligned(T* dst) const;
+
+        const T& operator[](std::size_t index) const;
+        T& operator[](std::size_t index);
+
+
+    private:
+
+        std::array<T, N> m_value;
+    };
+
+    template <typename T, std::size_t N>
+    batch<T, N> operator-(const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> operator+(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> operator-(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> operator*(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> operator/(const batch<T, N>& lhs, const batch<T, N>& rhs);
+
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator==(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator!=(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator<(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch_bool<T, N> operator<=(const batch<T, N>& lhs, const batch<T, N>& rhs);
+
+    template <typename T, std::size_t N>
+    batch<T, N> operator&(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> operator|(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> operator^(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> operator~(const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> bitwise_andnot(const batch<T, N>& lhs, const batch<T, N>& rhs);
+
+    template <typename T, std::size_t N>
+    batch<T, N> min(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> max(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> fmin(const batch<T, N>& lhs, const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> fmax(const batch<T, N>& lhs, const batch<T, N>& rhs);
+
+    template <typename T, std::size_t N>
+    batch<T, N> abs(const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> fabs(const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> sqrt(const batch<T, N>& rhs);
+
+    template <typename T, std::size_t N>
+    batch<T, N> fma(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z);
+    template <typename T, std::size_t N>
+    batch<T, N> fms(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z);
+    template <typename T, std::size_t N>
+    batch<T, N> fnma(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z);
+    template <typename T, std::size_t N>
+    batch<T, N> fnms(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z);
+
+    template <typename T, std::size_t N>
+    T hadd(const batch<T, N>& rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> haddp(const batch<T, N>* row);
+
+    template <typename T, std::size_t N>
+    batch<T, N> select(const batch_bool<T, N>& cond, const batch<T, N>& a, const batch<T, N>& b);
+
+    template <typename T, std::size_t N>
+    batch_bool<T, N> isnan(const batch<T, N>& x);
+
+    template <typename T, std::size_t N>
+    batch<T, N> operator<<(const batch<T, N>& lhs, int32_t rhs);
+    template <typename T, std::size_t N>
+    batch<T, N> operator>>(const batch<T, N>& lhs, int32_t rhs);
+
+    /************************
+     * conversion functions *
+     ************************/
+
+    template <std::size_t N>
+    batch<int32_t, N> to_int(const batch<float, N>& x);
+    template <std::size_t N>
+    batch<int64_t, N> to_int(const batch<double, N>& x);
+
+    template <std::size_t N>
+    batch<float, N> to_float(const batch<int32_t, N>& x);
+    template <std::size_t N>
+    batch<double, N> to_float(const batch<int64_t, N>& x);
+
+    /**************************
+     * boolean cast functions *
+     **************************/
+
+    template <std::size_t N>
+    batch_bool<int32_t, N> bool_cast(const batch_bool<float, N>& x);
+    template <std::size_t N>
+    batch_bool<int64_t, N> bool_cast(const batch_bool<double, N>& x);
+    template <std::size_t N>
+    batch_bool<float, N> bool_cast(const batch_bool<int32_t, N>& x);
+    template <std::size_t N>
+    batch_bool<double, N> bool_cast(const batch_bool<int64_t, N>& x);
+
+    /**************************************
+     * Ugly shared implementation details *
+     **************************************/
+
+    namespace detail
+    {
+        // Boilerplate to get index_sequence in c++11
+        // TODO: This should probably be moved to xtl
+        template <typename T>
+        struct identity { using type = T; };
+
+        #ifdef __cpp_lib_integer_sequence
+            using std::integer_sequence;
+            using std::index_sequence;
+            using std::make_index_sequence;
+            using std::index_sequence_for;
+        #else
+            template <typename T, T... Is>
+            struct integer_sequence {
+            using value_type = T;
+            static constexpr std::size_t size() noexcept { return sizeof...(Is); }
+            };
+
+            template <std::size_t... Is>
+            using index_sequence = integer_sequence<std::size_t, Is...>;
+
+            template <typename Lhs, typename Rhs>
+            struct make_index_sequence_concat;
+
+            template <std::size_t... Lhs, std::size_t... Rhs>
+            struct make_index_sequence_concat<index_sequence<Lhs...>,
+                                            index_sequence<Rhs...>>
+              : identity<index_sequence<Lhs..., (sizeof...(Lhs) + Rhs)...>> {};
+
+            template <std::size_t N>
+            struct make_index_sequence_impl;
+
+            template <std::size_t N>
+            using make_index_sequence = typename make_index_sequence_impl<N>::type;
+
+            template <std::size_t N>
+            struct make_index_sequence_impl
+              : make_index_sequence_concat<make_index_sequence<N / 2>,
+                                           make_index_sequence<N - (N / 2)>> {};
+
+            template <>
+            struct make_index_sequence_impl<0> : identity<index_sequence<>> {};
+
+            template <>
+            struct make_index_sequence_impl<1> : identity<index_sequence<0>> {};
+
+            template <typename... Ts>
+            using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+        #endif
+
+        // Tools for reinterpreting stuff as an unsigned integer
+        template <typename T>
+        struct as_unsigned;
+
+        template <>
+        struct as_unsigned<float> {
+            using type = uint32_t;
+        };
+
+        template <>
+        struct as_unsigned<double> {
+            using type = uint64_t;
+        };
+
+        template <>
+        struct as_unsigned<int32_t> {
+            using type = uint32_t;
+        };
+
+        template <>
+        struct as_unsigned<int64_t> {
+            using type = uint64_t;
+        };
+
+        template <typename T>
+        union unsigned_convertor {
+            T data;
+            typename as_unsigned<T>::type bits;
+        };
+
+        template <typename T>
+        struct to_unsigned {
+            using output = typename as_unsigned<T>::type;
+
+            static output run(const T& input) {
+                unsigned_convertor<T> convertor;
+                convertor.data = input;
+                return convertor.bits;
+            }
+        };
+
+        template <typename T>
+        struct from_unsigned {
+            static T run(const typename as_unsigned<T>::type& input) {
+                unsigned_convertor<T> convertor;
+                convertor.bits = input;
+                return convertor.data;
+            }
+        };
+
+        // std::array constructor from scalar value ("broadcast")
+        template <typename T, std::size_t N>
+        constexpr std::array<T, N>
+        array_from_scalar(const T& scalar) {
+            return array_from_scalar_impl(scalar, make_index_sequence<N>());
+        }
+
+        template <typename T, std::size_t... Is>
+        constexpr std::array<T, sizeof...(Is)>
+        array_from_scalar_impl(const T& scalar, index_sequence<Is...>) {
+            // You can safely ignore this silly ternary, the "scalar" is all
+            // that matters. The rest is just a dirty workaround...
+            return std::array<T, sizeof...(Is)>{ (Is+1) ? scalar : (T)0 ... };
+        }
+
+        // std::array constructor from C-style pointer (handled as an array)
+        template <typename T, std::size_t N>
+        constexpr std::array<T, N>
+        array_from_pointer(const T* c_array) {
+            return array_from_pointer_impl(c_array, make_index_sequence<N>());
+        }
+
+        template <typename T, std::size_t... Is>
+        constexpr std::array<T, sizeof...(Is)>
+        array_from_pointer_impl(const T* c_array, index_sequence<Is...>) {
+            return std::array<T, sizeof...(Is)>{ c_array[Is]... };
+        }
+    }
+
+// Boilerplate generators. All of these asume that T and N are in scope and have
+// the meaning used in the batch and batch_bool template definitions.
+#define XSIMD_FALLBACK_MAPPING_LOOP(RESULT_TYPE, EXPRESSION)  \
+    RESULT_TYPE<T, N> result;  \
+    for(std::size_t i = 0; i < N; ++i) {  \
+        result[i] = (EXPRESSION);  \
+    }  \
+    return result;
+
+#define XSIMD_FALLBACK_UNARY_OP(RESULT_TYPE, OPERATOR)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(RESULT_TYPE, (OPERATOR rhs[i]))
+
+#define XSIMD_FALLBACK_BINARY_OP(RESULT_TYPE, OPERATOR)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(RESULT_TYPE, (lhs[i] OPERATOR rhs[i]))
+
+#define XSIMD_FALLBACK_BATCH_BITWISE_UNARY_OP(OPERATOR)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(  \
+        batch,  \
+        detail::from_unsigned<T>::run(  \
+            OPERATOR detail::to_unsigned<T>::run(rhs[i])  \
+        )  \
+    )
+
+#define XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(OPERATOR)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(  \
+        batch,  \
+        detail::from_unsigned<T>::run(  \
+            detail::to_unsigned<T>::run(lhs[i])  \
+            OPERATOR  \
+            detail::to_unsigned<T>::run(rhs[i])  \
+        )  \
+    )
+
+#define XSIMD_FALLBACK_BATCH_UNARY_FUNC(FUNCTION)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(batch, FUNCTION(rhs[i]))
+
+#define XSIMD_FALLBACK_BATCH_BINARY_FUNC(FUNCTION)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(batch, FUNCTION(lhs[i], rhs[i]))
+
+#define XSIMD_FALLBACK_BATCH_TERNARY_FUNC(FUNCTION)  \
+    XSIMD_FALLBACK_MAPPING_LOOP(batch, FUNCTION(x[i], y[i], z[i]))
+
+// NOTE: Static casting a vector is static casting every element
+#define XSIMD_FALLBACK_BATCH_STATIC_CAST(T_OUT)  \
+    batch<T_OUT, N> result;  \
+    for(std::size_t i = 0; i < N; ++i) {  \
+        result[i] = static_cast<T_OUT>(x[i]);  \
+    }  \
+    return result;
+
+// NOTE: Casting between batch_bools of the same size is actually trivial!
+#define XSIMD_FALLBACK_BOOL_CAST(T_OUT)  \
+    return batch_bool<T_OUT, N>(static_cast<std::array<bool, N>>(x));
+
+    /***********************************
+     * batch_bool<T, N> implementation *
+     ***********************************/
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N>::batch_bool()
+    {
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N>::batch_bool(bool b)
+        : m_value(detail::array_from_scalar<bool, N>(b))
+    {
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N>::batch_bool(const std::array<bool, N>& rhs)
+        : m_value(rhs)
+    {
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N>& batch_bool<T, N>::operator=(const std::array<bool, N>& rhs)
+    {
+        m_value = rhs;
+        return *this;
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N>::operator std::array<bool, N>() const
+    {
+        return m_value;
+    }
+
+    template <typename T, std::size_t N>
+    inline const bool& batch_bool<T, N>::operator[](std::size_t index) const
+    {
+        return m_value[index];
+    }
+
+    template <typename T, std::size_t N>
+    inline bool& batch_bool<T, N>::operator[](std::size_t index)
+    {
+        return m_value[index];
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator&(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, &)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator|(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, |)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator^(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, ^)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator~(const batch_bool<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_UNARY_OP(batch_bool, ~)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> bitwise_andnot(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_MAPPING_LOOP(batch_bool, (~(lhs[i] & rhs[i])))
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator==(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, ==)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator!=(const batch_bool<T, N>& lhs, const batch_bool<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, !=)
+    }
+
+    template <typename T, std::size_t N>
+    inline bool all(const batch_bool<T, N>& rhs)
+    {
+        for(std::size_t i = 0; i < N; ++i) {
+            if(!rhs[i]) return false;
+        }
+        return true;
+    }
+
+    template <typename T, std::size_t N>
+    inline bool any(const batch_bool<T, N>& rhs)
+    {
+        for(std::size_t i = 0; i < N; ++i) {
+            if(rhs[i]) return true;
+        }
+        return false;
+    }
+
+    /**********************************
+     * batch<T, N> implementation *
+     **********************************/
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>::batch()
+    {
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>::batch(T f)
+        : m_value(detail::array_from_scalar<T, N>(f))
+    {
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>::batch(const T* src)
+        : batch(src, unaligned_mode())
+    {
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>::batch(const T* src, aligned_mode)
+        : batch(src, unaligned_mode())
+    {
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>::batch(const T* src, unaligned_mode)
+        : m_value(detail::array_from_pointer<T, N>(src))
+    {
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>::batch(const std::array<T, N>& rhs)
+        : m_value(rhs)
+    {
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::operator=(const std::array<T, N>& rhs)
+    {
+        m_value = rhs;
+        return *this;
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>::operator std::array<T, N>() const
+    {
+        return m_value;
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::load_aligned(const T* src)
+    {
+        return this->load_unaligned(src);
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N>& batch<T, N>::load_unaligned(const T* src)
+    {
+        m_value = detail::array_from_pointer<T, N>(src);
+        return *this;
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_aligned(T* dst) const
+    {
+        this->store_unaligned(dst);
+    }
+
+    template <typename T, std::size_t N>
+    inline void batch<T, N>::store_unaligned(T* dst) const
+    {
+        for(std::size_t i = 0; i < N; ++i) {
+            dst[i] = m_value[i];
+        }
+    }
+
+    template <typename T, std::size_t N>
+    inline const T& batch<T, N>::operator[](std::size_t index) const
+    {
+        return m_value[index];
+    }
+
+    template <typename T, std::size_t N>
+    inline T& batch<T, N>::operator[](std::size_t index)
+    {
+        return m_value[index];
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator-(const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_UNARY_OP(batch, -)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator+(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch, +)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator-(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch, -)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator*(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch, *)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator/(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch, /)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator==(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, ==)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator!=(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, !=)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator<(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, <)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> operator<=(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BINARY_OP(batch_bool, <=)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator&(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(&)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator|(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(|)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator^(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_BITWISE_BINARY_OP(^)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator~(const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_BITWISE_UNARY_OP(~)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> bitwise_andnot(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_MAPPING_LOOP(
+            batch,
+            detail::from_unsigned<T>::run(
+                ~(
+                    detail::to_unsigned<T>::run(lhs[i])
+                    &
+                    detail::to_unsigned<T>::run(rhs[i])
+                )
+            )
+        )
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> min(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::min)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> max(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::max)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> fmin(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::fmin)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> fmax(const batch<T, N>& lhs, const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_BINARY_FUNC(std::fmax)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> abs(const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::abs)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> fabs(const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::fabs)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> sqrt(const batch<T, N>& rhs)
+    {
+        XSIMD_FALLBACK_BATCH_UNARY_FUNC(std::sqrt)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> fma(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z)
+    {
+        XSIMD_FALLBACK_BATCH_TERNARY_FUNC(std::fma)
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> fms(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z)
+    {
+        return fma(x, y, -z);
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> fnma(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z)
+    {
+        return fma(-x, y, z);
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> fnms(const batch<T, N>& x, const batch<T, N>& y, const batch<T, N>& z)
+    {
+        return fma(-x, y, -z);
+    }
+
+    template <typename T, std::size_t N>
+    inline T hadd(const batch<T, N>& rhs)
+    {
+        T result = 0;
+        for(std::size_t i = 0; i < N; ++i) {
+            result += rhs[i];
+        }
+        return result;
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> haddp(const batch<T, N>* row)
+    {
+        XSIMD_FALLBACK_MAPPING_LOOP(batch, hadd(row[i]))
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> select(const batch_bool<T, N>& cond, const batch<T, N>& a, const batch<T, N>& b)
+    {
+        XSIMD_FALLBACK_MAPPING_LOOP(batch, (cond[i] ? a[i] : b[i]))
+    }
+
+    template <typename T, std::size_t N>
+    inline batch_bool<T, N> isnan(const batch<T, N>& x)
+    {
+        XSIMD_FALLBACK_MAPPING_LOOP(batch_bool, std::isnan(x[i]))
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator<<(const batch<T, N>& lhs, int32_t rhs) {
+        XSIMD_FALLBACK_MAPPING_LOOP(batch, (lhs[i] << rhs))
+    }
+
+    template <typename T, std::size_t N>
+    inline batch<T, N> operator>>(const batch<T, N>& lhs, int32_t rhs) {
+        XSIMD_FALLBACK_MAPPING_LOOP(batch, (lhs[i] >> rhs))
+    }
+
+    /***************************************
+     * conversion functions implementation *
+     ***************************************/
+
+    template <std::size_t N>
+    inline batch<int32_t, N> to_int(const batch<float, N>& x)
+    {
+        XSIMD_FALLBACK_BATCH_STATIC_CAST(int32_t)
+    }
+
+    template <std::size_t N>
+    inline batch<int64_t, N> to_int(const batch<double, N>& x)
+    {
+        XSIMD_FALLBACK_BATCH_STATIC_CAST(int64_t)
+    }
+
+    template <std::size_t N>
+    inline batch<float, N> to_float(const batch<int32_t, N>& x)
+    {
+        XSIMD_FALLBACK_BATCH_STATIC_CAST(float)
+    }
+
+    template <std::size_t N>
+    inline batch<double, N> to_float(const batch<int64_t, N>& x)
+    {
+        XSIMD_FALLBACK_BATCH_STATIC_CAST(double)
+    }
+
+    /**************************
+     * boolean cast functions *
+     **************************/
+
+    template <std::size_t N>
+    inline batch_bool<int32_t, N> bool_cast(const batch_bool<float, N>& x)
+    {
+        XSIMD_FALLBACK_BOOL_CAST(int32_t)
+    }
+
+    template <std::size_t N>
+    inline batch_bool<int64_t, N> bool_cast(const batch_bool<double, N>& x)
+    {
+        XSIMD_FALLBACK_BOOL_CAST(int64_t)
+    }
+
+    template <std::size_t N>
+    inline batch_bool<float, N> bool_cast(const batch_bool<int32_t, N>& x)
+    {
+        XSIMD_FALLBACK_BOOL_CAST(float)
+    }
+
+    template <std::size_t N>
+    inline batch_bool<double, N> bool_cast(const batch_bool<int64_t, N>& x)
+    {
+        XSIMD_FALLBACK_BOOL_CAST(double)
+    }
+
+    /*****************************************
+     * bitwise cast functions implementation *
+     *****************************************/
+
+    template <class T_in, class T_out, std::size_t N_in>
+    struct bitwise_cast_impl<batch<T_in, N_in>,
+                             batch<T_out, sizeof(T_in)*N_in/sizeof(T_out)>>
+    {
+    private:
+        static_assert(sizeof(T_in)*N_in % sizeof(T_out) == 0,
+                      "The input and output batches must have the same size");
+        static constexpr size_t N_out = sizeof(T_in)*N_in/sizeof(T_out);
+
+        union Converter {
+            std::array<T_in, N_in> in;
+            std::array<T_out, N_out> out;
+        };
+
+    public:
+        static batch<T_out, N_out> run(const batch<T_in, N_in>& x) {
+            Converter caster;
+            caster.in = static_cast<std::array<T_in, N_in>>(x);
+            return batch<T_out, N_out>(caster.out);
+        }
+    };
+}
+
+#endif

--- a/include/xsimd/types/xsimd_neon_bool.hpp
+++ b/include/xsimd/types/xsimd_neon_bool.hpp
@@ -78,6 +78,8 @@ namespace xsimd
 
         operator simd_type() const;
 
+        bool operator[](std::size_t index) const;
+
     private:
 
         simd_type m_value;
@@ -207,6 +209,12 @@ namespace xsimd
     }
 
     template <class T>
+    inline bool batch_bool<T, 4>::operator[](std::size_t index) const
+    {
+        return static_cast<bool>(m_value[index]);
+    }
+
+    template <class T>
     inline bool all(const batch_bool<T, 4>& rhs)
     {
         uint32x2_t tmp = vand_u32(vget_low_u32(rhs), vget_high_u32(rhs));
@@ -246,6 +254,8 @@ namespace xsimd
         batch_bool& operator=(const simd_type& rhs);
 
         operator simd_type() const;
+
+        bool operator[](std::size_t index) const;
 
     private:
 
@@ -364,6 +374,12 @@ namespace xsimd
     inline batch_bool<T, 2>::operator uint64x2_t() const
     {
         return m_value;
+    }
+
+    template <class T>
+    inline bool batch_bool<T, 2>::operator[](std::size_t index) const
+    {
+        return static_cast<bool>(m_value[index]);
     }
 
     template <class T>

--- a/include/xsimd/types/xsimd_neon_conversion.hpp
+++ b/include/xsimd/types/xsimd_neon_conversion.hpp
@@ -44,24 +44,6 @@ namespace xsimd
     batch_bool<double, 2> bool_cast(const batch_bool<int64_t, 2>& x);
 #endif
 
-    /**************************
-     * bitwise cast functions *
-     **************************/
-
-    template <class B>
-    B bitwise_cast(const batch<float, 4>& x);
-
-#if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
-    template <class B>
-    B bitwise_cast(const batch<double, 2>& x);
-#endif
-
-    template <class B>
-    B bitwise_cast(const batch<int32_t, 4>& x);
-
-    template <class B>
-    B bitwise_cast(const batch<int64_t, 2>& x);
-
     /***************************************
      * conversion functions implementation *
      ***************************************/
@@ -118,67 +100,46 @@ namespace xsimd
      * bitwise cast functions implementation *
      *****************************************/
 
-    template <>
-    inline batch<int32_t, 4> bitwise_cast(const batch<float, 4>& x)
-    {
-        return vreinterpretq_s32_f32(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
+                                 int32_t, 4,
+                                 vreinterpretq_s32_f32)
 
-    template <>
-    inline batch<int64_t, 2> bitwise_cast(const batch<float, 4>& x)
-    {
-        return vreinterpretq_s64_f32(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
+                                 int64_t, 2,
+                                 vreinterpretq_s64_f32)
 
-    template <>
-    inline batch<float, 4> bitwise_cast(const batch<int32_t, 4>& x)
-    {
-        return vreinterpretq_f32_s32(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4,
+                                 float, 4,
+                                 vreinterpretq_f32_s32)
 
-
-    template <>
-    inline batch<float, 4> bitwise_cast(const batch<int64_t, 2>& x)
-    {
-        return vreinterpretq_f32_s64(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2,
+                                 float, 4,
+                                 vreinterpretq_f32_s64)
 
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
-    template <>
-    inline batch<float, 4> bitwise_cast(const batch<double, 2>& x)
-    {
-        return vreinterpretq_f32_f64(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
+                                 float, 4,
+                                 vreinterpretq_f32_f64)
 
-    template <>
-    inline batch<int32_t, 4> bitwise_cast(const batch<double, 2>& x)
-    {
-        return vreinterpretq_s32_f64(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
+                                 int32_t, 4,
+                                 vreinterpretq_s32_f64)
 
-    template <>
-    inline batch<int64_t, 2> bitwise_cast(const batch<double, 2>& x)
-    {
-        return vreinterpretq_s64_f64(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
+                                 int64_t, 2,
+                                 vreinterpretq_s64_f64)
 
-    template <>
-    inline batch<double, 2> bitwise_cast(const batch<int32_t, 4>& x)
-    {
-        return vreinterpretq_f64_s32(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4,
+                                 double, 2,
+                                 vreinterpretq_f64_s32)
 
-    template <>
-    inline batch<double, 2> bitwise_cast(const batch<int64_t, 2>& x)
-    {
-        return vreinterpretq_f64_s64(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2,
+                                 double, 2,
+                                 vreinterpretq_f64_s64)
 
-    template <>
-    inline batch<double, 2> bitwise_cast(const batch<float, 4>& x)
-    {
-        return vreinterpretq_f64_f32(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
+                                 double, 2,
+                                 vreinterpretq_f64_f32)
 #endif
 
 }

--- a/include/xsimd/types/xsimd_sse_conversion.hpp
+++ b/include/xsimd/types/xsimd_sse_conversion.hpp
@@ -36,22 +36,6 @@ namespace xsimd
     batch_bool<float, 4> bool_cast(const batch_bool<int32_t, 4>& x);
     batch_bool<double, 2> bool_cast(const batch_bool<int64_t, 2>& x);
 
-    /**************************
-     * bitwise cast functions *
-     **************************/
-
-    template <class B>
-    B bitwise_cast(const batch<float, 4>& x);
-
-    template <class B>
-    B bitwise_cast(const batch<double, 2>& x);
-
-    template <class B>
-    B bitwise_cast(const batch<int32_t, 4>& x);
-
-    template <class B>
-    B bitwise_cast(const batch<int64_t, 2>& x);
-
     /***************************************
      * conversion functions implementation *
      ***************************************/
@@ -106,65 +90,45 @@ namespace xsimd
      * bitwise cast functions implementation *
      *****************************************/
 
-    template <>
-    inline batch<double, 2> bitwise_cast(const batch<float, 4>& x)
-    {
-        return _mm_castps_pd(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
+                                 double, 2,
+                                 _mm_castps_pd)
 
-    template <>
-    inline batch<int32_t, 4> bitwise_cast(const batch<float, 4>& x)
-    {
-        return _mm_castps_si128(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
+                                 int32_t, 4,
+                                 _mm_castps_si128)
 
-    template <>
-    inline batch<int64_t, 2> bitwise_cast(const batch<float, 4>& x)
-    {
-        return _mm_castps_si128(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
+                                 int64_t, 2,
+                                 _mm_castps_si128)
 
-    template <>
-    inline batch<float, 4> bitwise_cast(const batch<double, 2>& x)
-    {
-        return _mm_castpd_ps(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
+                                 float, 4,
+                                 _mm_castpd_ps)
 
-    template <>
-    inline batch<int32_t, 4> bitwise_cast(const batch<double, 2>& x)
-    {
-        return _mm_castpd_si128(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
+                                 int32_t, 4,
+                                 _mm_castpd_si128)
 
-    template <>
-    inline batch<int64_t, 2> bitwise_cast(const batch<double, 2>& x)
-    {
-        return _mm_castpd_si128(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
+                                 int64_t, 2,
+                                 _mm_castpd_si128)
 
-    template <>
-    inline batch<float, 4> bitwise_cast(const batch<int32_t, 4>& x)
-    {
-        return _mm_castsi128_ps(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4,
+                                 float, 4,
+                                 _mm_castsi128_ps)
 
-    template <>
-    inline batch<double, 2> bitwise_cast(const batch<int32_t, 4>& x)
-    {
-        return _mm_castsi128_pd(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4,
+                                 double, 2,
+                                 _mm_castsi128_pd)
 
-    template <>
-    inline batch<float, 4> bitwise_cast(const batch<int64_t, 2>& x)
-    {
-        return _mm_castsi128_ps(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2,
+                                 float, 4,
+                                 _mm_castsi128_ps)
 
-    template <>
-    inline batch<double, 2> bitwise_cast(const batch<int64_t, 2>& x)
-    {
-        return _mm_castsi128_pd(x);
-    }
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2,
+                                 double, 2,
+                                 _mm_castsi128_pd)
 }
 
 #endif

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -40,6 +40,8 @@ namespace xsimd
 
         operator __m128d() const;
 
+        bool operator[](std::size_t index) const;
+
     private:
 
         __m128d m_value;
@@ -187,6 +189,13 @@ namespace xsimd
     inline batch_bool<double, 2>::operator __m128d() const
     {
         return m_value;
+    }
+
+    inline bool batch_bool<double, 2>::operator[](std::size_t index) const
+    {
+        alignas(16) double x[2];
+        _mm_store_pd(x, m_value);
+        return static_cast<bool>(x[index & 1]);
     }
 
     inline batch_bool<double, 2> operator&(const batch_bool<double, 2>& lhs, const batch_bool<double, 2>& rhs)

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -40,6 +40,8 @@ namespace xsimd
 
         operator __m128() const;
 
+        bool operator[](std::size_t index) const;
+
     private:
 
         __m128 m_value;
@@ -187,6 +189,13 @@ namespace xsimd
     inline batch_bool<float, 4>::operator __m128() const
     {
         return m_value;
+    }
+
+    inline bool batch_bool<float, 4>::operator[](std::size_t index) const
+    {
+        alignas(16) float x[4];
+        _mm_store_ps(x, m_value);
+        return static_cast<bool>(x[index & 3]);
     }
 
     inline batch_bool<float, 4> operator&(const batch_bool<float, 4>& lhs, const batch_bool<float, 4>& rhs)

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -42,6 +42,8 @@ namespace xsimd
 
         operator __m128i() const;
 
+        bool operator[](std::size_t index) const;
+
     private:
 
         __m128i m_value;
@@ -185,6 +187,13 @@ namespace xsimd
     inline batch_bool<int32_t, 4>::operator __m128i() const
     {
         return m_value;
+    }
+
+    inline bool batch_bool<int32_t, 4>::operator[](std::size_t index) const
+    {
+        alignas(16) int32_t x[4];
+        _mm_store_si128((__m128i*)x, m_value);
+        return static_cast<bool>(x[index & 3]);
     }
 
     inline batch_bool<int32_t, 4> operator&(const batch_bool<int32_t, 4>& lhs, const batch_bool<int32_t, 4>& rhs)

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -42,6 +42,8 @@ namespace xsimd
 
         operator __m128i() const;
 
+        bool operator[](std::size_t index) const;
+
     private:
 
         __m128i m_value;
@@ -201,6 +203,13 @@ namespace xsimd
     inline batch_bool<int64_t, 2>::operator __m128i() const
     {
         return m_value;
+    }
+
+    inline bool batch_bool<int64_t, 2>::operator[](std::size_t index) const
+    {
+        alignas(16) int64_t x[2];
+        _mm_store_si128((__m128i*)x, m_value);
+        return static_cast<bool>(x[index & 1]);
     }
 
     inline batch_bool<int64_t, 2> operator&(const batch_bool<int64_t, 2>& lhs, const batch_bool<int64_t, 2>& rhs)

--- a/include/xsimd/types/xsimd_types_include.hpp
+++ b/include/xsimd/types/xsimd_types_include.hpp
@@ -11,6 +11,9 @@
 
 #include "../config/xsimd_include.hpp"
 
+// Must be declared first (if used), as it defines the "general case"
+#include "xsimd_fallback.hpp"
+
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
 #include "xsimd_sse_conversion.hpp"
 #include "xsimd_sse_double.hpp"

--- a/include/xsimd/types/xsimd_types_include.hpp
+++ b/include/xsimd/types/xsimd_types_include.hpp
@@ -11,8 +11,9 @@
 
 #include "../config/xsimd_include.hpp"
 
-// Must be declared first (if used), as it defines the "general case"
+#if defined(XSIMD_ENABLE_FALLBACK)
 #include "xsimd_fallback.hpp"
+#endif
 
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE2_VERSION
 #include "xsimd_sse_conversion.hpp"

--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -64,6 +64,18 @@ namespace xsimd
         using type = uint64_t;
     };
 
+    template <>
+    struct as_unsigned_integer<int32_t>
+    {
+        using type = uint32_t;
+    };
+
+    template <>
+    struct as_unsigned_integer<int64_t>
+    {
+        using type = uint64_t;
+    };
+
     template <class T, std::size_t N>
     struct as_unsigned_integer<batch<T, N>>
     {
@@ -157,6 +169,150 @@ namespace xsimd
 
         template <class T>
         using caster_t = typename caster<T>::type;
+    }
+
+    /****************************
+     * to/from_unsigned_integer *
+     ****************************/
+
+    namespace detail
+    {
+        template <typename T>
+        union unsigned_convertor {
+            T data;
+            as_unsigned_integer_t<T> bits;
+        };
+
+        template <typename T>
+        as_unsigned_integer_t<T> to_unsigned_integer(const T& input) {
+            unsigned_convertor<T> convertor;
+            convertor.data = input;
+            return convertor.bits;
+        }
+
+        template <typename T>
+        T from_unsigned_integer(const as_unsigned_integer_t<T>& input) {
+            unsigned_convertor<T> convertor;
+            convertor.bits = input;
+            return convertor.data;
+        }
+    }
+
+    /*****************************************
+     * Backport of index_sequence from c++14 *
+     *****************************************/
+
+    // TODO: Remove this once we drop C++11 support
+    namespace detail
+    {
+        template <typename T>
+        struct identity { using type = T; };
+
+        #ifdef __cpp_lib_integer_sequence
+            using std::integer_sequence;
+            using std::index_sequence;
+            using std::make_index_sequence;
+            using std::index_sequence_for;
+        #else
+            template <typename T, T... Is>
+            struct integer_sequence {
+            using value_type = T;
+            static constexpr std::size_t size() noexcept { return sizeof...(Is); }
+            };
+
+            template <std::size_t... Is>
+            using index_sequence = integer_sequence<std::size_t, Is...>;
+
+            template <typename Lhs, typename Rhs>
+            struct make_index_sequence_concat;
+
+            template <std::size_t... Lhs, std::size_t... Rhs>
+            struct make_index_sequence_concat<index_sequence<Lhs...>,
+                                            index_sequence<Rhs...>>
+              : identity<index_sequence<Lhs..., (sizeof...(Lhs) + Rhs)...>> {};
+
+            template <std::size_t N>
+            struct make_index_sequence_impl;
+
+            template <std::size_t N>
+            using make_index_sequence = typename make_index_sequence_impl<N>::type;
+
+            template <std::size_t N>
+            struct make_index_sequence_impl
+              : make_index_sequence_concat<make_index_sequence<N / 2>,
+                                           make_index_sequence<N - (N / 2)>> {};
+
+            template <>
+            struct make_index_sequence_impl<0> : identity<index_sequence<>> {};
+
+            template <>
+            struct make_index_sequence_impl<1> : identity<index_sequence<0>> {};
+
+            template <typename... Ts>
+            using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+        #endif
+    }
+
+    /*****************************************
+     * Supplementary std::array constructors *
+     *****************************************/
+
+    namespace detail
+    {
+        // std::array constructor from scalar value ("broadcast")
+        template <typename T, std::size_t... Is>
+        constexpr std::array<T, sizeof...(Is)>
+        array_from_scalar_impl(const T& scalar, index_sequence<Is...>) {
+            // You can safely ignore this silly ternary, the "scalar" is all
+            // that matters. The rest is just a dirty workaround...
+            return std::array<T, sizeof...(Is)>{ (Is+1) ? scalar : T() ... };
+        }
+
+        template <typename T, std::size_t N>
+        constexpr std::array<T, N>
+        array_from_scalar(const T& scalar) {
+            return array_from_scalar_impl(scalar, make_index_sequence<N>());
+        }
+
+        // std::array constructor from C-style pointer (handled as an array)
+        template <typename T, std::size_t... Is>
+        constexpr std::array<T, sizeof...(Is)>
+        array_from_pointer_impl(const T* c_array, index_sequence<Is...>) {
+            return std::array<T, sizeof...(Is)>{ c_array[Is]... };
+        }
+
+        template <typename T, std::size_t N>
+        constexpr std::array<T, N>
+        array_from_pointer(const T* c_array) {
+            return array_from_pointer_impl(c_array, make_index_sequence<N>());
+        }
+    }
+
+    /************************
+     * is_array_initializer *
+     ************************/
+
+    namespace detail
+    {
+        template <bool...> struct bool_pack;
+
+        template <bool... bs>
+        using all_true = std::is_same<
+            bool_pack<bs..., true>, bool_pack<true, bs...>
+        >;
+
+        template <typename T, typename... Args>
+        using is_only_this_type = all_true<std::is_same<Args, T>::value...>;
+
+        template <typename T, std::size_t N, typename... Args>
+        using is_array_initializer = std::enable_if<
+            (sizeof...(Args) == N) && is_only_this_type<T, Args...>::value
+        >;
+
+        // Check that a variadic argument pack is a list of N values of type T,
+        // as usable for instantiating a value of type std::array<T, N>.
+        template <typename T, std::size_t N, typename... Args>
+        using is_array_initializer_t = typename is_array_initializer<T, N, Args...>::type;
     }
 }
 

--- a/test/xsimd_basic_math_test.cpp
+++ b/test/xsimd_basic_math_test.cpp
@@ -75,6 +75,7 @@ TEST(xsimd, neon_double_basic_math)
 }
 #endif
 
+#if defined(XSIMD_ENABLE_FALLBACK)
 TEST(xsimd, fallback_float_basic_math)
 {
     std::ofstream out("log/fallback_float_basic_math.log", std::ios_base::out);
@@ -88,3 +89,4 @@ TEST(xsimd, fallback_double_basic_math)
     bool res = xsimd::test_basic_math<double, 3, 32>(out, "fallback double");
     EXPECT_TRUE(res);
 }
+#endif

--- a/test/xsimd_basic_math_test.cpp
+++ b/test/xsimd_basic_math_test.cpp
@@ -74,3 +74,17 @@ TEST(xsimd, neon_double_basic_math)
     EXPECT_TRUE(res);
 }
 #endif
+
+TEST(xsimd, fallback_float_basic_math)
+{
+    std::ofstream out("log/fallback_float_basic_math.log", std::ios_base::out);
+    bool res = xsimd::test_basic_math<float, 7, 16>(out, "fallback float");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_double_basic_math)
+{
+    std::ofstream out("log/fallback_double_basic_math.log", std::ios_base::out);
+    bool res = xsimd::test_basic_math<double, 3, 32>(out, "fallback double");
+    EXPECT_TRUE(res);
+}

--- a/test/xsimd_basic_test.cpp
+++ b/test/xsimd_basic_test.cpp
@@ -236,3 +236,59 @@ TEST(xsimd, neon_store)
 }
 #endif
 #endif
+
+TEST(xsimd, fallback_float_basic)
+{
+    std::ofstream out("log/fallback_float_basic.log", std::ios_base::out);
+    bool res = xsimd::test_simd<float, 7, 32>(out, "fallback float");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_int32_basic)
+{
+    std::ofstream out("log/fallback_int32_basic.log", std::ios_base::out);
+    bool res = xsimd::test_simd_int<int32_t, 7, 32>(out, "fallback int32");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_int64_basic)
+{
+    std::ofstream out("log/fallback_int64_basic.log", std::ios_base::out);
+    bool res = xsimd::test_simd_int<int64_t, 3, 32>(out, "fallback int64");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_double_basic)
+{
+    std::ofstream out("log/fallback_double_basic.log", std::ios_base::out);
+    bool res = xsimd::test_simd<double, 3, 32>(out, "fallback double");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_conversion)
+{
+    std::ofstream out("log/fallback_conversion.log", std::ios_base::out);
+    bool res = xsimd::test_simd_convert<3, 32>(out, "fallback conversion");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_cast)
+{
+    std::ofstream out("log/fallback_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_cast<3, 32>(out, "fallback cast");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_load)
+{
+    std::ofstream out("log/fallback_load.log", std::ios_base::out);
+    bool res = xsimd::test_simd_load<3, 32>(out, "fallback load");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_store)
+{
+    std::ofstream out("log/fallback_store.log", std::ios_base::out);
+    bool res = xsimd::test_simd_store<3, 32>(out, "fallback store");
+    EXPECT_TRUE(res);
+}

--- a/test/xsimd_basic_test.cpp
+++ b/test/xsimd_basic_test.cpp
@@ -237,6 +237,7 @@ TEST(xsimd, neon_store)
 #endif
 #endif
 
+#if defined(XSIMD_ENABLE_FALLBACK)
 TEST(xsimd, fallback_float_basic)
 {
     std::ofstream out("log/fallback_float_basic.log", std::ios_base::out);
@@ -292,3 +293,4 @@ TEST(xsimd, fallback_store)
     bool res = xsimd::test_simd_store<3, 32>(out, "fallback store");
     EXPECT_TRUE(res);
 }
+#endif

--- a/test/xsimd_error_gamma_test.cpp
+++ b/test/xsimd_error_gamma_test.cpp
@@ -76,6 +76,7 @@ TEST(xsimd, neon_double_error_gamma)
 }
 #endif
 
+#if defined(XSIMD_ENABLE_FALLBACK)
 TEST(xsimd, fallback_float_error_gamma)
 {
     std::ofstream out("log/fallback_float_error_gamma.log", std::ios_base::out);
@@ -89,3 +90,4 @@ TEST(xsimd, fallback_double_error_gamma)
     bool res = xsimd::test_error_gamma<double, 3, 32>(out, "fallback double");
     EXPECT_TRUE(res);
 }
+#endif

--- a/test/xsimd_error_gamma_test.cpp
+++ b/test/xsimd_error_gamma_test.cpp
@@ -75,3 +75,17 @@ TEST(xsimd, neon_double_error_gamma)
     EXPECT_TRUE(res);
 }
 #endif
+
+TEST(xsimd, fallback_float_error_gamma)
+{
+    std::ofstream out("log/fallback_float_error_gamma.log", std::ios_base::out);
+    bool res = xsimd::test_error_gamma<float, 7, 32>(out, "fallback float");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_double_error_gamma)
+{
+    std::ofstream out("log/fallback_double_exponential.log", std::ios_base::out);
+    bool res = xsimd::test_error_gamma<double, 3, 32>(out, "fallback double");
+    EXPECT_TRUE(res);
+}

--- a/test/xsimd_exponential_test.cpp
+++ b/test/xsimd_exponential_test.cpp
@@ -75,3 +75,17 @@ TEST(xsimd, neon_double_exponential)
     EXPECT_TRUE(res);
 }
 #endif
+
+TEST(xsimd, fallback_float_exponential)
+{
+    std::ofstream out("log/fallback_float_exponential.log", std::ios_base::out);
+    bool res = xsimd::test_exponential<float, 7, 32>(out, "fallback float");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_double_exponential)
+{
+    std::ofstream out("log/fallback_double_exponential.log", std::ios_base::out);
+    bool res = xsimd::test_exponential<double, 3, 32>(out, "fallback double");
+    EXPECT_TRUE(res);
+}

--- a/test/xsimd_exponential_test.cpp
+++ b/test/xsimd_exponential_test.cpp
@@ -76,6 +76,7 @@ TEST(xsimd, neon_double_exponential)
 }
 #endif
 
+#if defined(XSIMD_ENABLE_FALLBACK)
 TEST(xsimd, fallback_float_exponential)
 {
     std::ofstream out("log/fallback_float_exponential.log", std::ios_base::out);
@@ -89,3 +90,4 @@ TEST(xsimd, fallback_double_exponential)
     bool res = xsimd::test_exponential<double, 3, 32>(out, "fallback double");
     EXPECT_TRUE(res);
 }
+#endif

--- a/test/xsimd_fp_manipulation_test.cpp
+++ b/test/xsimd_fp_manipulation_test.cpp
@@ -75,6 +75,7 @@ TEST(xsimd, neon_double_fp_manipulation)
 }
 #endif
 
+#if defined(XSIMD_ENABLE_FALLBACK)
 TEST(xsimd, fallback_float_fp_manipulation)
 {
     std::ofstream out("log/fallback_float_fp_manipulation.log", std::ios_base::out);
@@ -88,3 +89,4 @@ TEST(xsimd, fallback_double_fp_manipulation)
     bool res = xsimd::test_fp_manipulation<double, 3, 32>(out, "fallback double");
     EXPECT_TRUE(res);
 }
+#endif

--- a/test/xsimd_fp_manipulation_test.cpp
+++ b/test/xsimd_fp_manipulation_test.cpp
@@ -74,3 +74,17 @@ TEST(xsimd, neon_double_fp_manipulation)
     EXPECT_TRUE(res);
 }
 #endif
+
+TEST(xsimd, fallback_float_fp_manipulation)
+{
+    std::ofstream out("log/fallback_float_fp_manipulation.log", std::ios_base::out);
+    bool res = xsimd::test_fp_manipulation<float, 7, 32>(out, "fallback float");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_double_fp_manipulation)
+{
+    std::ofstream out("log/fallback_double_fp_manipulation.log", std::ios_base::out);
+    bool res = xsimd::test_fp_manipulation<double, 3, 32>(out, "fallback double");
+    EXPECT_TRUE(res);
+}

--- a/test/xsimd_hyperbolic_test.cpp
+++ b/test/xsimd_hyperbolic_test.cpp
@@ -75,6 +75,7 @@ TEST(xsimd, neon_double_hyperbolic)
 }
 #endif
 
+#if defined(XSIMD_ENABLE_FALLBACK)
 TEST(xsimd, fallback_float_hyperbolic)
 {
     std::ofstream out("log/fallback_float_hyperbolic.log", std::ios_base::out);
@@ -88,3 +89,4 @@ TEST(xsimd, fallback_double_hyperbolic)
     bool res = xsimd::test_hyperbolic<double, 3, 32>(out, "fallback double");
     EXPECT_TRUE(res);
 }
+#endif

--- a/test/xsimd_hyperbolic_test.cpp
+++ b/test/xsimd_hyperbolic_test.cpp
@@ -74,3 +74,17 @@ TEST(xsimd, neon_double_hyperbolic)
     EXPECT_TRUE(res);
 }
 #endif
+
+TEST(xsimd, fallback_float_hyperbolic)
+{
+    std::ofstream out("log/fallback_float_hyperbolic.log", std::ios_base::out);
+    bool res = xsimd::test_hyperbolic<float, 7, 32>(out, "fallback float");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_double_hyperbolic)
+{
+    std::ofstream out("log/fallback_double_hyperbolic.log", std::ios_base::out);
+    bool res = xsimd::test_hyperbolic<double, 3, 32>(out, "fallback double");
+    EXPECT_TRUE(res);
+}

--- a/test/xsimd_power_test.cpp
+++ b/test/xsimd_power_test.cpp
@@ -74,3 +74,17 @@ TEST(xsimd, neon_double_power)
     EXPECT_TRUE(res);
 }
 #endif
+
+TEST(xsimd, fallback_float_power)
+{
+    std::ofstream out("log/fallback_float_power.log", std::ios_base::out);
+    bool res = xsimd::test_power<float, 7, 32>(out, "fallback float");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_double_power)
+{
+    std::ofstream out("log/fallback_double_power.log", std::ios_base::out);
+    bool res = xsimd::test_power<double, 3, 32>(out, "fallback double");
+    EXPECT_TRUE(res);
+}

--- a/test/xsimd_power_test.cpp
+++ b/test/xsimd_power_test.cpp
@@ -75,6 +75,7 @@ TEST(xsimd, neon_double_power)
 }
 #endif
 
+#if defined(XSIMD_ENABLE_FALLBACK)
 TEST(xsimd, fallback_float_power)
 {
     std::ofstream out("log/fallback_float_power.log", std::ios_base::out);
@@ -88,3 +89,4 @@ TEST(xsimd, fallback_double_power)
     bool res = xsimd::test_power<double, 3, 32>(out, "fallback double");
     EXPECT_TRUE(res);
 }
+#endif

--- a/test/xsimd_rounding_test.cpp
+++ b/test/xsimd_rounding_test.cpp
@@ -74,3 +74,17 @@ TEST(xsimd, neon_double_rounding)
     EXPECT_TRUE(res);
 }
 #endif
+
+TEST(xsimd, fallback_float_rounding)
+{
+    std::ofstream out("log/fallback_float_rounding.log", std::ios_base::out);
+    bool res = xsimd::test_rounding<float, 7, 32>(out, "fallback float");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_double_rounding)
+{
+    std::ofstream out("log/fallback_double_rounding.log", std::ios_base::out);
+    bool res = xsimd::test_rounding<double, 3, 32>(out, "fallback double");
+    EXPECT_TRUE(res);
+}

--- a/test/xsimd_rounding_test.cpp
+++ b/test/xsimd_rounding_test.cpp
@@ -75,6 +75,7 @@ TEST(xsimd, neon_double_rounding)
 }
 #endif
 
+#if defined(XSIMD_ENABLE_FALLBACK)
 TEST(xsimd, fallback_float_rounding)
 {
     std::ofstream out("log/fallback_float_rounding.log", std::ios_base::out);
@@ -88,3 +89,4 @@ TEST(xsimd, fallback_double_rounding)
     bool res = xsimd::test_rounding<double, 3, 32>(out, "fallback double");
     EXPECT_TRUE(res);
 }
+#endif

--- a/test/xsimd_trigonometric_test.cpp
+++ b/test/xsimd_trigonometric_test.cpp
@@ -74,3 +74,17 @@ TEST(xsimd, neon_double_trigonometric)
     EXPECT_TRUE(res);
 }
 #endif
+
+TEST(xsimd, fallback_float_trigonometric)
+{
+    std::ofstream out("log/fallback_float_trigonometric.log", std::ios_base::out);
+    bool res = xsimd::test_trigonometric<float, 7, 32>(out, "fallback float");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, fallback_double_trigonometric)
+{
+    std::ofstream out("log/fallback_double_trigonometric.log", std::ios_base::out);
+    bool res = xsimd::test_trigonometric<double, 3, 32>(out, "fallback double");
+    EXPECT_TRUE(res);
+}

--- a/test/xsimd_trigonometric_test.cpp
+++ b/test/xsimd_trigonometric_test.cpp
@@ -75,6 +75,7 @@ TEST(xsimd, neon_double_trigonometric)
 }
 #endif
 
+#if defined(XSIMD_ENABLE_FALLBACK)
 TEST(xsimd, fallback_float_trigonometric)
 {
     std::ofstream out("log/fallback_float_trigonometric.log", std::ios_base::out);
@@ -88,3 +89,4 @@ TEST(xsimd, fallback_double_trigonometric)
     bool res = xsimd::test_trigonometric<double, 3, 32>(out, "fallback double");
     EXPECT_TRUE(res);
 }
+#endif


### PR DESCRIPTION
This MR strives to be a hack-free version of #88 . It is mostly a rewrite, using the existing branch as inspiration when things go wrong. The end goal is to get a fallback version of `batch<T, N>` which compiles down to scalar loops, that may or may not be autovectorized by the compiler.

While I was at it, I also cleaned a couple of minor things along the way, such as the inability to print or query batch_bool.

Current status:

- [x] Write the "type" header
- [x] Rework the bitwise_cast API (in a backwards-compatible way) to allow genericity over vector length
- [x] Generalize the math functions to arbitrary vector lengths
- [x] Integrate the fallback in the benchmarks
- [x] Integrate it in the tests
- [x] Get the thing to compile, link, run, and pass tests :)
- [x] Resolve memory corruption in xbenchmark
- [x] Check that there is no non-fallback performance regression
- [x] Add a way to disable the fallback or detect if it is used
- [x] Discuss what should be done with stuff in the detail namespace
- [x] Discuss how to best document this
- [ ] Discuss running CI with and without the fallback
