### PR TITLE
fix for Intel on Windows

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
         include_directories(/usr/${ARM_ARCH_DIRECTORY}/include/c++/${ARM_GCC_VER}/)
         include_directories(/usr/${ARM_ARCH_DIRECTORY}/include/)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${TARGET_ARCH} -Wunused-parameter -Wextra -Wreorder -std=c++11")
-    else()
+    elseif(NOT WIN32)
         CHECK_CXX_COMPILER_FLAG("-std=c++11" HAS_CPP11_FLAG)
         if (HAS_CPP11_FLAG)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fPIC -march=${TARGET_ARCH} -Wunused-parameter -Wextra -Wreorder -std=c++11")


### PR DESCRIPTION
This prevent the check of c++11 flags for Intel compiler on Windows and should fix #125, however I'm not sure how to set the correct flags for activating SSE / AVX for this compiler on Windows.