### PR TITLE
increase NEON float accuracy for sqrt

### DIFF
--- a/include/xsimd/types/xsimd_neon_float.hpp
+++ b/include/xsimd/types/xsimd_neon_float.hpp
@@ -462,7 +462,7 @@ namespace xsimd
 #else
                 batch<float, 4> sqrt_reciprocal = vrsqrteq_f32(rhs);
                 // one iter
-                // sqrt_reciprocal = sqrt_reciprocal * vrsqrtsq_f32(lhs * sqrt_reciprocal, sqrt_reciprocal);
+                sqrt_reciprocal = sqrt_reciprocal * batch<float, 4>(vrsqrtsq_f32(rhs * sqrt_reciprocal, sqrt_reciprocal));
                 batch<float, 4> sqrt_approx = rhs * sqrt_reciprocal * batch<float, 4>(vrsqrtsq_f32(rhs * sqrt_reciprocal, sqrt_reciprocal));
                 batch<float, 4> zero(0.f);
                 return select(rhs == zero, zero, sqrt_approx);

--- a/test/xsimd_test_utils.hpp
+++ b/test/xsimd_test_utils.hpp
@@ -24,7 +24,7 @@
 #include "xtl/xcomplex.hpp"
 #endif
 
-#define DEBUG_FLOAT_ACCURACY 0
+#define DEBUG_FLOAT_ACCURACY 1
 
 namespace xsimd
 {

--- a/test/xsimd_test_utils.hpp
+++ b/test/xsimd_test_utils.hpp
@@ -24,7 +24,7 @@
 #include "xtl/xcomplex.hpp"
 #endif
 
-#define DEBUG_FLOAT_ACCURACY 1
+#define DEBUG_FLOAT_ACCURACY 0
 
 namespace xsimd
 {


### PR DESCRIPTION
This PR increases the approximation accuracy for calculating the square root of a floating point number on pre-ARMv8 hardware. 

It helps to alleviate accuracy problems we've observed in the complex implementation. 

The remaining failing test is `complex tan`. 