### PR TITLE
Fix missing semicolons.

### DIFF
--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -304,13 +304,13 @@ namespace xsimd
         struct batch_bool_kernel<int8_t, 64>
             : avx512_fallback_batch_bool_kernel<int8_t, 64>
         {
-        }
+        };
 
         template <>
         struct batch_bool_kernel<uint8_t, 64>
             : avx512_fallback_batch_bool_kernel<int8_t, 64>
         {
-        }
+        };
     }
 #endif
 


### PR DESCRIPTION
I was mucking around with compiler flags on an AVX512 machine and spotted what look like a couple of cases of missing semicolons on class template specialisations.