### PR TITLE
Changed default cmake behavior to not build the tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ install:
   - conda info -a
   - conda install gtest cmake -c conda-forge
   - conda install xtl -c quantstack
-  - cmake -G "NMake Makefiles" -D ENABLE_XTL_COMPLEX=1 -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -D CMAKE_BUILD_TYPE=Release .
+  - cmake -G "NMake Makefiles" -D BUILD_TESTS=1 -D ENABLE_XTL_COMPLEX=1 -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -D CMAKE_BUILD_TYPE=Release .
   - nmake test_xsimd
   - cd test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,23 +138,23 @@ install:
           ln -s /usr/bin/aarch64-linux-gnu-ld $HOME/linker_bin/ld ;
           echo "SETTING GNU LINKER DIR" ;
           ls -al $HOME/linker_bin/ld ;
-          cmake . -DCROSS_COMPILE_ARM=ON -DDOWNLOAD_GTEST=ON -DARM_ARCH_DIRECTORY="$ARM_ARCH_DIR" -DARM_GCC_VER="$GCC_VER" -DTARGET_ARCH="$ARM_SETTINGS --prefix=$HOME/linker_bin/" ;
+          cmake . -DBUILD_TESTS=ON -DCROSS_COMPILE_ARM=ON -DDOWNLOAD_GTEST=ON -DARM_ARCH_DIRECTORY="$ARM_ARCH_DIR" -DARM_GCC_VER="$GCC_VER" -DTARGET_ARCH="$ARM_SETTINGS --prefix=$HOME/linker_bin/" ;
         else
-          cmake . -DCROSS_COMPILE_ARM=ON -DDOWNLOAD_GTEST=ON -DARM_ARCH_DIRECTORY="$ARM_ARCH_DIR" -DARM_GCC_VER="$GCC_VER" -DTARGET_ARCH="$ARM_SETTINGS" ;
+          cmake . -DBUILD_TESTS=ON -DCROSS_COMPILE_ARM=ON -DDOWNLOAD_GTEST=ON -DARM_ARCH_DIRECTORY="$ARM_ARCH_DIR" -DARM_GCC_VER="$GCC_VER" -DTARGET_ARCH="$ARM_SETTINGS" ;
         fi
       elif [[ "$ENABLE_FALLBACK" == 1 ]] ; then
-        cmake -DENABLE_FALLBACK=ON -DENABLE_XTL_COMPLEX=ON . ;
+        cmake -DBUILD_TESTS=ON -DENABLE_FALLBACK=ON -DENABLE_XTL_COMPLEX=ON . ;
       elif [[ "$ENABLE_XTL_COMPLEX" == 1 ]] ; then
-        cmake -DENABLE_XTL_COMPLEX=ON . ;
+        cmake -DBUILD_TESTS=ON -DENABLE_XTL_COMPLEX=ON . ;
       elif [[ "$AVX512" == 1 ]] ; then
         conda install gcc_linux-64 gxx_linux-64;
         sh install_sde.sh ;
         export PATH="$HOME/miniconda/bin:$PATH" ;
         export CC=x86_64-conda_cos6-linux-gnu-gcc CXX=x86_64-conda_cos6-linux-gnu-g++ ;
         which $CXX ;
-        cmake . -DTARGET_ARCH=skylake-avx512 -DCMAKE_INSTALL_PREFIX=$HOME/miniconda -DDOWNLOAD_GTEST=ON ;
+        cmake . -DBUILD_TESTS=ON -DTARGET_ARCH=skylake-avx512 -DCMAKE_INSTALL_PREFIX=$HOME/miniconda -DDOWNLOAD_GTEST=ON ;
       else
-        cmake . ;
+        cmake . -DBUILD_TESTS=ON ;
       fi
     - make -j2 test_xsimd
     - cd test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ foreach(ver ${xsimd_version_defines})
         set(XSIMD_VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
     endif()
 endforeach()
-set(${PROJECT_NAME}_VERSION 
+set(${PROJECT_NAME}_VERSION
     ${XSIMD_VERSION_MAJOR}.${XSIMD_VERSION_MINOR}.${XSIMD_VERSION_PATCH})
 message(STATUS "xsimd v${${PROJECT_NAME}_VERSION}")
 
@@ -102,7 +102,7 @@ target_include_directories(xsimd INTERFACE $<BUILD_INTERFACE:${XSIMD_INCLUDE_DIR
 
 OPTION(ENABLE_FALLBACK "build tests/benchmarks with fallback implementation" OFF)
 OPTION(ENABLE_XTL_COMPLEX "enables support for xcomplex defined in xtl" OFF)
-OPTION(BUILD_TESTS "xsimd test suite" ON)
+OPTION(BUILD_TESTS "xsimd test suite" OFF)
 OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Once `gtest` and `cmake` are installed, you can build and run the tests:
 ```bash
 mkdir build
 cd build
-cmake ../
+cmake ../ -DBUILD_TESTS=ON
 make xtest
 ```
 
@@ -142,7 +142,7 @@ cd test
 conda env create -f ./test-environment.yml
 source activate test-xsimd
 cd ..
-cmake .
+cmake . -DBUILD_TESTS=ON
 make xtest
 ```
 


### PR DESCRIPTION
This facilitates the `make install` feature. If the tests are build one has to worry about `gtest` which could be a nuisance if one just wants to install the header-only library.