### PR TITLE
Disambiguate function calls for ARM NEON

### DIFF
--- a/include/xsimd/math/xsimd_numerical_constant.hpp
+++ b/include/xsimd/math/xsimd_numerical_constant.hpp
@@ -42,7 +42,7 @@ namespace xsimd
     template <>                                         \
     constexpr float NAME<float>() noexcept              \
     {                                                   \
-        return detail::caster32_t(SINGLE).f;            \
+      return detail::caster32_t(uint32_t(SINGLE)).f;	\
     }                                                   \
     template <>                                         \
     constexpr double NAME<double>() noexcept            \

--- a/include/xsimd/types/xsimd_neon_int32.hpp
+++ b/include/xsimd/types/xsimd_neon_int32.hpp
@@ -501,7 +501,7 @@ namespace xsimd
                 REPEAT_32(vshlq_n_s32, 0);
                 default: break;
             }
-            return batch<int32_t, 4>(0);
+            return batch<int32_t, 4>(int32_t(0));
         }
 
         inline batch<int32_t, 4> shift_right(const batch<int32_t, 4>& lhs, const int n)
@@ -512,7 +512,7 @@ namespace xsimd
                 REPEAT_32(vshrq_n_s32, 0);
                 default: break;
             }
-            return batch<int32_t, 4>(0);
+            return batch<int32_t, 4>(int32_t(0));
         }
     }
 


### PR DESCRIPTION
Hello

I became aware of xsimd through godbolt, and I wanted to see if I could use the compiler explorer to look at some generated assembly for an ARM Cortex-M7 target. The following however does not compile:

https://godbolt.org/z/LRw7w8

The issues are ambiguous function calls between

1. `inline batch<int32_t, 4>::batch` with `const int32_t*` vs `int32_t`
2. Calls to `generic_caster` through expansions of `XSIMD_DEFINE_CONSTANT_HEX`

For 1. I explicitly cast to `int32_t` since the pointer overload calls `vld1q_s32` which, if `0` were replaced with `nullptr`, would load from a null pointer? For 2. I cast to `uint32_t` just to complement what's done in the `DOUBLE` case.

Hopefully I've correctly understood the intention for both. 

With these changes, and adding `-flax-vector-conversions` as per https://github.com/QuantStack/xsimd/issues/147, the code compiles on my machine locally with the settings as above. 