### PR TITLE
add more int tests

### DIFF
--- a/include/xsimd/types/xsimd_avx_int8.hpp
+++ b/include/xsimd/types/xsimd_avx_int8.hpp
@@ -361,11 +361,18 @@ namespace xsimd
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
                 auto xor_lhs = _mm256_xor_si256(lhs, _mm256_set1_epi8(std::numeric_limits<int8_t>::lowest()));
                 auto xor_rhs = _mm256_xor_si256(rhs, _mm256_set1_epi8(std::numeric_limits<int8_t>::lowest()));
-                return _mm256_cmpgt_epi8(xor_lhs, xor_rhs);
+                return _mm256_cmpgt_epi8(xor_rhs, xor_lhs);
 #else
-                auto xor_lhs = _mm256_xor_si256(lhs, _mm256_set1_epi8(std::numeric_limits<int8_t>::lowest()));
-                auto xor_rhs = _mm256_xor_si256(rhs, _mm256_set1_epi8(std::numeric_limits<int8_t>::lowest()));
-                XSIMD_APPLY_SSE_FUNCTION(_mm_cmpgt_epi8, xor_lhs, xor_rhs);
+                XSIMD_SPLIT_AVX(lhs);
+                XSIMD_SPLIT_AVX(rhs);
+                auto xer = _mm_set1_epi8(std::numeric_limits<int8_t>::lowest());
+                lhs_low  = _mm_xor_si128(lhs_low,  xer);
+                lhs_high = _mm_xor_si128(lhs_high, xer);
+                rhs_low  = _mm_xor_si128(rhs_low,  xer);
+                rhs_high = _mm_xor_si128(rhs_high, xer);
+                __m128i res_low =  _mm_cmpgt_epi8(rhs_low, lhs_low);
+                __m128i res_high = _mm_cmpgt_epi8(rhs_high, lhs_high);
+                XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
             }
 

--- a/include/xsimd/types/xsimd_neon_int8.hpp
+++ b/include/xsimd/types/xsimd_neon_int8.hpp
@@ -92,7 +92,7 @@ namespace xsimd
 
     template <class... Args, class>
     inline batch<int8_t, 16>::batch(Args... args)
-        : m_value{args...}
+        : m_value{static_cast<int8_t>(args)...}
     {
     }
 

--- a/include/xsimd/types/xsimd_neon_uint8.hpp
+++ b/include/xsimd/types/xsimd_neon_uint8.hpp
@@ -82,7 +82,7 @@ namespace xsimd
 
     template <class... Args, class>
     inline batch<uint8_t, 16>::batch(Args... args)
-        : m_value{args...}
+        : m_value{static_cast<uint8_t>(args)...}
     {
     }
 


### PR DESCRIPTION
There was a bug with the lower-than operator for int8 & int16 types.
And removes usage of _mm256_xor_si256 from `AVX` (note the missing `2`) which did not compile /cc @serge-sans-paille 

additionally, this adds some more tests (also for the constructors from multiple values, incl. min/max of the int type).