### PR TITLE
Fix about endianness detection, support more platforms

### DIFF
--- a/include/xsimd/math/xsimd_rem_pio2.hpp
+++ b/include/xsimd/math/xsimd_rem_pio2.hpp
@@ -9,6 +9,9 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 
 namespace xsimd
 {
@@ -44,13 +47,21 @@ namespace xsimd
          * ====================================================
          */
 
-#if defined(i386) || defined(i486) ||                   \
+#if defined(__GNUC__) && defined(__BYTE_ORDER__)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define XSIMD_LITTLE_ENDIAN
+#endif
+#elif defined(_WIN32)
+#if REG_DWORD == REG_DWORD_LITTLE_ENDIAN
+#define XSIMD_LITTLE_ENDIAN
+#endif
+#elif defined(i386) || defined(i486) ||                 \
     defined(intel) || defined(x86) || defined(i86pc) || \
     defined(__alpha) || defined(__osf__)
-#define __LITTLE_ENDIAN
+#define XSIMD_LITTLE_ENDIAN
 #endif
 
-#ifdef __LITTLE_ENDIAN
+#ifdef XSIMD_LITTLE_ENDIAN
 #define LOW_WORD_IDX 0
 #define HIGH_WORD_IDX sizeof(std::uint32_t)
 #else
@@ -622,6 +633,7 @@ namespace xsimd
         }
     }
 
+#undef XSIMD_LITTLE_ENDIAN
 #undef SET_LOW_WORD
 #undef SET_HIGH_WORD
 #undef GET_LOW_WORD

--- a/include/xsimd/math/xsimd_rem_pio2.hpp
+++ b/include/xsimd/math/xsimd_rem_pio2.hpp
@@ -9,9 +9,6 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#if defined(_WIN32)
-#include <windows.h>
-#endif
 
 namespace xsimd
 {
@@ -49,10 +46,6 @@ namespace xsimd
 
 #if defined(__GNUC__) && defined(__BYTE_ORDER__)
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define XSIMD_LITTLE_ENDIAN
-#endif
-#elif defined(_WIN32)
-#if REG_DWORD == REG_DWORD_LITTLE_ENDIAN
 #define XSIMD_LITTLE_ENDIAN
 #endif
 #elif defined(i386) || defined(i486) ||                 \


### PR DESCRIPTION
#178 

renaming `__LITTLE_ENDIAN` and attempting to detect on common platforms and compilers: windows, gcc, clang.
By no means I expect this detection to be exhaustive, but I hope it covers a good deal.
Little endianness would not be detected on Linux OS prior.