### PR TITLE
Eliminate unnecessary semicolons in macros.

### DIFF
--- a/include/xsimd/types/xsimd_avx512_double.hpp
+++ b/include/xsimd/types/xsimd_avx512_double.hpp
@@ -79,8 +79,8 @@ namespace xsimd
 
         operator __m512d() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(double, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(double, 8);
+        XSIMD_DECLARE_LOAD_STORE_ALL(double, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(double, 8)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;

--- a/include/xsimd/types/xsimd_avx512_float.hpp
+++ b/include/xsimd/types/xsimd_avx512_float.hpp
@@ -81,8 +81,8 @@ namespace xsimd
 
         operator __m512() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(float, 16);
-        XSIMD_DECLARE_LOAD_STORE_LONG(float, 16);
+        XSIMD_DECLARE_LOAD_STORE_ALL(float, 16)
+        XSIMD_DECLARE_LOAD_STORE_LONG(float, 16)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;

--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -168,8 +168,8 @@ namespace xsimd
         {
         }
 
-        XSIMD_DECLARE_LOAD_STORE_INT16(int16_t, 32);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 32);
+        XSIMD_DECLARE_LOAD_STORE_INT16(int16_t, 32)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 32)
     };
 
     template <>
@@ -184,8 +184,8 @@ namespace xsimd
         using base_class::store_aligned;
         using base_class::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT16(uint16_t, 32);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 32);
+        XSIMD_DECLARE_LOAD_STORE_INT16(uint16_t, 32)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 32)
     };
 
     batch<int16_t, 32> operator<<(const batch<int16_t, 32>& lhs, int32_t rhs);

--- a/include/xsimd/types/xsimd_avx512_int32.hpp
+++ b/include/xsimd/types/xsimd_avx512_int32.hpp
@@ -106,8 +106,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT32(int32_t, 16);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 16);
+        XSIMD_DECLARE_LOAD_STORE_INT32(int32_t, 16)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 16)
     };
 
     template <>
@@ -122,8 +122,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT32(uint32_t, 16);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 16);
+        XSIMD_DECLARE_LOAD_STORE_INT32(uint32_t, 16)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 16)
     };
 
     batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, int32_t rhs);

--- a/include/xsimd/types/xsimd_avx512_int64.hpp
+++ b/include/xsimd/types/xsimd_avx512_int64.hpp
@@ -107,8 +107,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT64(int64_t, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 8);
+        XSIMD_DECLARE_LOAD_STORE_INT64(int64_t, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 8)
    };
 
     template <>
@@ -123,8 +123,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT64(uint64_t, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 8);
+        XSIMD_DECLARE_LOAD_STORE_INT64(uint64_t, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 8)
    };
 
     batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, int32_t rhs);

--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -168,8 +168,8 @@ namespace xsimd
         {
         }
 
-        XSIMD_DECLARE_LOAD_STORE_INT8(int8_t, 64);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 64);
+        XSIMD_DECLARE_LOAD_STORE_INT8(int8_t, 64)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 64)
     };
 
     template <>
@@ -184,8 +184,8 @@ namespace xsimd
         using base_class::store_aligned;
         using base_class::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT8(uint8_t, 64);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 64);
+        XSIMD_DECLARE_LOAD_STORE_INT8(uint8_t, 64)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 64)
     };
 
     batch<int8_t, 64> operator<<(const batch<int8_t, 64>& lhs, int32_t rhs);

--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -79,8 +79,8 @@ namespace xsimd
 
         operator __m256d() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(double, 4);
-        XSIMD_DECLARE_LOAD_STORE_LONG(double, 4);
+        XSIMD_DECLARE_LOAD_STORE_ALL(double, 4)
+        XSIMD_DECLARE_LOAD_STORE_LONG(double, 4)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;
@@ -315,9 +315,9 @@ namespace xsimd
         return *this;
     }
 
-    XSIMD_DEFINE_LOAD_STORE(double, 4, uint32_t, 32);
-    XSIMD_DEFINE_LOAD_STORE(double, 4, int64_t, 32);
-    XSIMD_DEFINE_LOAD_STORE(double, 4, uint64_t, 32);
+    XSIMD_DEFINE_LOAD_STORE(double, 4, uint32_t, 32)
+    XSIMD_DEFINE_LOAD_STORE(double, 4, int64_t, 32)
+    XSIMD_DEFINE_LOAD_STORE(double, 4, uint64_t, 32)
     XSIMD_DEFINE_LOAD_STORE_LONG(double, 4, 32)
 
     inline batch<double, 4>& batch<double, 4>::load_aligned(const float* src)

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -82,8 +82,8 @@ namespace xsimd
 
         operator __m256() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(float, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(float, 8);
+        XSIMD_DECLARE_LOAD_STORE_ALL(float, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(float, 8)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;

--- a/include/xsimd/types/xsimd_avx_int16.hpp
+++ b/include/xsimd/types/xsimd_avx_int16.hpp
@@ -100,8 +100,8 @@ namespace xsimd
         using base_class::store_aligned;
         using base_class::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT16(int16_t, 16);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 16);
+        XSIMD_DECLARE_LOAD_STORE_INT16(int16_t, 16)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 16)
     };
 
     template <>
@@ -116,8 +116,8 @@ namespace xsimd
         using base_class::store_aligned;
         using base_class::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT16(uint16_t, 16);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 16);
+        XSIMD_DECLARE_LOAD_STORE_INT16(uint16_t, 16)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 16)
     };
 
     /*************************************

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -101,8 +101,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT32(int32_t, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 8);
+        XSIMD_DECLARE_LOAD_STORE_INT32(int32_t, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 8)
    };
 
     batch<int32_t, 8> operator<<(const batch<int32_t, 8>& lhs, int32_t rhs);
@@ -120,8 +120,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT32(uint32_t, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 8);
+        XSIMD_DECLARE_LOAD_STORE_INT32(uint32_t, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 8)
     };
 
     batch<uint32_t, 8> operator<<(const batch<uint32_t, 8>& lhs, int32_t rhs);

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -102,8 +102,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT64(int64_t, 4);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 4);
+        XSIMD_DECLARE_LOAD_STORE_INT64(int64_t, 4)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 4)
     };
 
     template <>
@@ -118,8 +118,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT64(uint64_t, 4);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 4);
+        XSIMD_DECLARE_LOAD_STORE_INT64(uint64_t, 4)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 4)
     };
 
     batch<int64_t, 4> operator<<(const batch<int64_t, 4>& lhs, int32_t rhs);

--- a/include/xsimd/types/xsimd_avx_int8.hpp
+++ b/include/xsimd/types/xsimd_avx_int8.hpp
@@ -117,8 +117,8 @@ namespace xsimd
         {
         }
 
-        XSIMD_DECLARE_LOAD_STORE_INT8(int8_t, 32);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 32);
+        XSIMD_DECLARE_LOAD_STORE_INT8(int8_t, 32)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 32)
     };
 
     template <>
@@ -133,8 +133,8 @@ namespace xsimd
         using base_class::store_aligned;
         using base_class::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT8(uint8_t, 32);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 32);
+        XSIMD_DECLARE_LOAD_STORE_INT8(uint8_t, 32)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 32)
     };
 
     batch<int8_t, 32> operator<<(const batch<int8_t, 32>& lhs, int32_t rhs);
@@ -412,7 +412,7 @@ namespace xsimd
         }, lhs, rhs);
     }
 
-    XSIMD_DEFINE_LOAD_STORE_INT8(int8_t, 32, 32);
+    XSIMD_DEFINE_LOAD_STORE_INT8(int8_t, 32, 32)
     XSIMD_DEFINE_LOAD_STORE_LONG(int8_t, 32, 32)
 
     inline batch<uint8_t, 32> operator<<(const batch<uint8_t, 32>& lhs, int32_t rhs)
@@ -429,7 +429,7 @@ namespace xsimd
         }, lhs, rhs);
     }
 
-    XSIMD_DEFINE_LOAD_STORE_INT8(uint8_t, 32, 32);
+    XSIMD_DEFINE_LOAD_STORE_INT8(uint8_t, 32, 32)
     XSIMD_DEFINE_LOAD_STORE_LONG(uint8_t, 32, 32)
 }
 

--- a/include/xsimd/types/xsimd_base.hpp
+++ b/include/xsimd/types/xsimd_base.hpp
@@ -390,7 +390,7 @@ namespace xsimd
     batch<TYPE, N>& load_aligned(const CVT_TYPE*);                             \
     batch<TYPE, N>& load_unaligned(const CVT_TYPE*);                           \
     void store_aligned(CVT_TYPE* dst) const;                                   \
-    void store_unaligned(CVT_TYPE* dst) const
+    void store_unaligned(CVT_TYPE* dst) const;
 
 #define XSIMD_DEFINE_LOAD_STORE(TYPE, N, CVT_TYPE, ALIGNMENT)                  \
     inline batch<TYPE, N>& batch<TYPE, N>::load_aligned(const CVT_TYPE* src)   \
@@ -421,7 +421,7 @@ namespace xsimd
 #ifdef XSIMD_32_BIT_ABI
 
 #define XSIMD_DECLARE_LOAD_STORE_LONG(TYPE, N)                                 \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, long);                                   \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, long)                                   \
     XSIMD_DECLARE_LOAD_STORE(TYPE, N, unsigned long)                           \
 
     namespace detail
@@ -479,13 +479,13 @@ namespace xsimd
 #endif // XSIMD_32_BIT_ABI
 
 #define XSIMD_DECLARE_LOAD_STORE_INT8(TYPE, N)                                 \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int16_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint16_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int32_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint32_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int64_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint64_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float);                                  \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int16_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint16_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int32_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint32_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int64_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint64_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float)                                   \
     XSIMD_DECLARE_LOAD_STORE(TYPE, N, double)
 
 #define XSIMD_DEFINE_LOAD_STORE_INT8(TYPE, N, ALIGNMENT)                       \
@@ -499,13 +499,13 @@ namespace xsimd
     XSIMD_DEFINE_LOAD_STORE(TYPE, N, double, ALIGNMENT)
 
 #define XSIMD_DECLARE_LOAD_STORE_INT16(TYPE, N)                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int8_t);                                 \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint8_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int32_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint32_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int64_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint64_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float);                                  \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int8_t)                                  \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint8_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int32_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint32_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int64_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint64_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float)                                   \
     XSIMD_DECLARE_LOAD_STORE(TYPE, N, double)
 
 #define XSIMD_DEFINE_LOAD_STORE_INT16(TYPE, N, ALIGNMENT)                      \
@@ -519,55 +519,55 @@ namespace xsimd
     XSIMD_DEFINE_LOAD_STORE(TYPE, N, double, ALIGNMENT)
 
 #define XSIMD_DECLARE_LOAD_STORE_INT32(TYPE, N)                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int8_t);                                 \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint8_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int16_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint16_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int64_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint64_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float);                                  \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int8_t)                                  \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint8_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int16_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint16_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int64_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint64_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float)                                   \
     XSIMD_DECLARE_LOAD_STORE(TYPE, N, double)
 
 #define XSIMD_DEFINE_LOAD_STORE_INT32(TYPE, N, ALIGNMENT)                      \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int8_t, ALIGNMENT);                       \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint8_t, ALIGNMENT);                      \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int16_t, ALIGNMENT);                      \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint16_t, ALIGNMENT);                     \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int64_t, ALIGNMENT);                      \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint64_t, ALIGNMENT);                     \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, float, ALIGNMENT);                        \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int8_t, ALIGNMENT)                        \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint8_t, ALIGNMENT)                       \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int16_t, ALIGNMENT)                       \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint16_t, ALIGNMENT)                      \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int64_t, ALIGNMENT)                       \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint64_t, ALIGNMENT)                      \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, float, ALIGNMENT)                         \
     XSIMD_DEFINE_LOAD_STORE(TYPE, N, double, ALIGNMENT)
 
 #define XSIMD_DECLARE_LOAD_STORE_INT64(TYPE, N)                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int8_t);                                 \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint8_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int16_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint16_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int32_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint32_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float);                                  \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int8_t)                                  \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint8_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int16_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint16_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int32_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint32_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float)                                   \
     XSIMD_DECLARE_LOAD_STORE(TYPE, N, double)
 
 #define XSIMD_DEFINE_LOAD_STORE_INT64(TYPE, N, ALIGNMENT)                      \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int8_t, ALIGNMENT);                       \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint8_t, ALIGNMENT);                      \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int16_t, ALIGNMENT);                      \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint16_t, ALIGNMENT);                     \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int32_t, ALIGNMENT);                      \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint32_t, ALIGNMENT);                     \
-    XSIMD_DEFINE_LOAD_STORE(TYPE, N, float, ALIGNMENT);                        \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int8_t, ALIGNMENT)                        \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint8_t, ALIGNMENT)                       \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int16_t, ALIGNMENT)                       \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint16_t, ALIGNMENT)                      \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, int32_t, ALIGNMENT)                       \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, uint32_t, ALIGNMENT)                      \
+    XSIMD_DEFINE_LOAD_STORE(TYPE, N, float, ALIGNMENT)                         \
     XSIMD_DEFINE_LOAD_STORE(TYPE, N, double, ALIGNMENT)
 
 #define XSIMD_DECLARE_LOAD_STORE_ALL(TYPE, N)                                  \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int8_t);                                 \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint8_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int16_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint16_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int32_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint32_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int64_t);                                \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint64_t);                               \
-    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float);                                  \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int8_t)                                  \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint8_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int16_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint16_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int32_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint32_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, int64_t)                                 \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, uint64_t)                                \
+    XSIMD_DECLARE_LOAD_STORE(TYPE, N, float)                                   \
     XSIMD_DECLARE_LOAD_STORE(TYPE, N, double)
 
     /**********************************

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -112,7 +112,7 @@ namespace xsimd
 
         operator std::array<T, N>() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(T, N);
+        XSIMD_DECLARE_LOAD_STORE_ALL(T, N)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;

--- a/include/xsimd/types/xsimd_neon_double.hpp
+++ b/include/xsimd/types/xsimd_neon_double.hpp
@@ -45,8 +45,8 @@ namespace xsimd
 
         operator simd_type() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(double, 2);
-        XSIMD_DECLARE_LOAD_STORE_LONG(double, 2);
+        XSIMD_DECLARE_LOAD_STORE_ALL(double, 2)
+        XSIMD_DECLARE_LOAD_STORE_LONG(double, 2)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;

--- a/include/xsimd/types/xsimd_neon_float.hpp
+++ b/include/xsimd/types/xsimd_neon_float.hpp
@@ -49,8 +49,8 @@ namespace xsimd
 
         operator simd_type() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(float, 4);
-        XSIMD_DECLARE_LOAD_STORE_LONG(float, 4);
+        XSIMD_DECLARE_LOAD_STORE_ALL(float, 4)
+        XSIMD_DECLARE_LOAD_STORE_LONG(float, 4)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;

--- a/include/xsimd/types/xsimd_neon_int16.hpp
+++ b/include/xsimd/types/xsimd_neon_int16.hpp
@@ -76,8 +76,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT16(int16_t, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 8);
+        XSIMD_DECLARE_LOAD_STORE_INT16(int16_t, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 8)
 
         int16_t operator[](std::size_t index) const;
 

--- a/include/xsimd/types/xsimd_neon_int32.hpp
+++ b/include/xsimd/types/xsimd_neon_int32.hpp
@@ -55,8 +55,8 @@ namespace xsimd
 
         operator simd_type() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(int32_t, 4);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 4);
+        XSIMD_DECLARE_LOAD_STORE_ALL(int32_t, 4)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 4)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;
@@ -119,8 +119,8 @@ namespace xsimd
         return *this;
     }
 
-    XSIMD_DEFINE_LOAD_STORE(int32_t, 4, int8_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(int32_t, 4, uint8_t, XSIMD_DEFAULT_ALIGNMENT);
+    XSIMD_DEFINE_LOAD_STORE(int32_t, 4, int8_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(int32_t, 4, uint8_t, XSIMD_DEFAULT_ALIGNMENT)
 
     inline batch<int32_t, 4>& batch<int32_t, 4>::load_aligned(const int16_t* src)
     {
@@ -168,8 +168,8 @@ namespace xsimd
         return load_aligned(src);
     }
 
-    XSIMD_DEFINE_LOAD_STORE(int32_t, 4, int64_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(int32_t, 4, uint64_t, XSIMD_DEFAULT_ALIGNMENT);
+    XSIMD_DEFINE_LOAD_STORE(int32_t, 4, int64_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(int32_t, 4, uint64_t, XSIMD_DEFAULT_ALIGNMENT)
     XSIMD_DEFINE_LOAD_STORE_LONG(int32_t, 4, 64)
 
     inline batch<int32_t, 4>& batch<int32_t, 4>::load_aligned(const float* src)

--- a/include/xsimd/types/xsimd_neon_int64.hpp
+++ b/include/xsimd/types/xsimd_neon_int64.hpp
@@ -51,8 +51,8 @@ namespace xsimd
 
         operator simd_type() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(int64_t, 2);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 2);
+        XSIMD_DECLARE_LOAD_STORE_ALL(int64_t, 2)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 2)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;
@@ -115,10 +115,10 @@ namespace xsimd
         return *this;
     }
 
-    XSIMD_DEFINE_LOAD_STORE(int64_t, 2, int8_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(int64_t, 2, uint8_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(int64_t, 2, int16_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(int64_t, 2, uint16_t, XSIMD_DEFAULT_ALIGNMENT);
+    XSIMD_DEFINE_LOAD_STORE(int64_t, 2, int8_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(int64_t, 2, uint8_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(int64_t, 2, int16_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(int64_t, 2, uint16_t, XSIMD_DEFAULT_ALIGNMENT)
 
     inline batch<int64_t, 2>& batch<int64_t, 2>::load_aligned(const int32_t* src)
     {

--- a/include/xsimd/types/xsimd_neon_int8.hpp
+++ b/include/xsimd/types/xsimd_neon_int8.hpp
@@ -75,8 +75,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT8(int8_t, 16);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 16);
+        XSIMD_DECLARE_LOAD_STORE_INT8(int8_t, 16)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 16)
 
         int8_t operator[](std::size_t index) const;
 

--- a/include/xsimd/types/xsimd_neon_uint16.hpp
+++ b/include/xsimd/types/xsimd_neon_uint16.hpp
@@ -72,8 +72,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT16(uint16_t, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 8);
+        XSIMD_DECLARE_LOAD_STORE_INT16(uint16_t, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 8)
 
         uint16_t operator[](std::size_t index) const;
 

--- a/include/xsimd/types/xsimd_neon_uint32.hpp
+++ b/include/xsimd/types/xsimd_neon_uint32.hpp
@@ -55,8 +55,8 @@ namespace xsimd
 
         operator simd_type() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(uint32_t, 4);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 4);
+        XSIMD_DECLARE_LOAD_STORE_ALL(uint32_t, 4)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 4)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;
@@ -119,8 +119,8 @@ namespace xsimd
         return *this;
     }
 
-    XSIMD_DEFINE_LOAD_STORE(uint32_t, 4, int8_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(uint32_t, 4, uint8_t, XSIMD_DEFAULT_ALIGNMENT);
+    XSIMD_DEFINE_LOAD_STORE(uint32_t, 4, int8_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(uint32_t, 4, uint8_t, XSIMD_DEFAULT_ALIGNMENT)
 
     inline batch<uint32_t, 4>& batch<uint32_t, 4>::load_aligned(const int16_t* src)
     {
@@ -168,9 +168,9 @@ namespace xsimd
         return load_aligned(src);
     }
 
-    XSIMD_DEFINE_LOAD_STORE(uint32_t, 4, int64_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(uint32_t, 4, uint64_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE_LONG(uint32_t, 4, 64);
+    XSIMD_DEFINE_LOAD_STORE(uint32_t, 4, int64_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(uint32_t, 4, uint64_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE_LONG(uint32_t, 4, 64)
 
     inline batch<uint32_t, 4>& batch<uint32_t, 4>::load_aligned(const float* src)
     {

--- a/include/xsimd/types/xsimd_neon_uint64.hpp
+++ b/include/xsimd/types/xsimd_neon_uint64.hpp
@@ -52,8 +52,8 @@ namespace xsimd
 
         operator simd_type() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(uint64_t, 2);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 2);
+        XSIMD_DECLARE_LOAD_STORE_ALL(uint64_t, 2)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 2)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;
@@ -116,10 +116,10 @@ namespace xsimd
         return *this;
     }
 
-    XSIMD_DEFINE_LOAD_STORE(uint64_t, 2, int8_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(uint64_t, 2, uint8_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(uint64_t, 2, int16_t, XSIMD_DEFAULT_ALIGNMENT);
-    XSIMD_DEFINE_LOAD_STORE(uint64_t, 2, uint16_t, XSIMD_DEFAULT_ALIGNMENT);
+    XSIMD_DEFINE_LOAD_STORE(uint64_t, 2, int8_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(uint64_t, 2, uint8_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(uint64_t, 2, int16_t, XSIMD_DEFAULT_ALIGNMENT)
+    XSIMD_DEFINE_LOAD_STORE(uint64_t, 2, uint16_t, XSIMD_DEFAULT_ALIGNMENT)
 
     inline batch<uint64_t, 2>& batch<uint64_t, 2>::load_aligned(const int32_t* src)
     {

--- a/include/xsimd/types/xsimd_neon_uint8.hpp
+++ b/include/xsimd/types/xsimd_neon_uint8.hpp
@@ -71,8 +71,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT8(uint8_t, 16);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 16);
+        XSIMD_DECLARE_LOAD_STORE_INT8(uint8_t, 16)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 16)
 
         uint8_t operator[](std::size_t index) const;
 

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -79,8 +79,8 @@ namespace xsimd
 
         operator __m128d() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(double, 2);
-        XSIMD_DECLARE_LOAD_STORE_LONG(double, 2);
+        XSIMD_DECLARE_LOAD_STORE_ALL(double, 2)
+        XSIMD_DECLARE_LOAD_STORE_LONG(double, 2)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -79,8 +79,8 @@ namespace xsimd
 
         operator __m128() const;
 
-        XSIMD_DECLARE_LOAD_STORE_ALL(float, 4);
-        XSIMD_DECLARE_LOAD_STORE_LONG(float, 4);
+        XSIMD_DECLARE_LOAD_STORE_ALL(float, 4)
+        XSIMD_DECLARE_LOAD_STORE_LONG(float, 4)
 
         using base_type::load_aligned;
         using base_type::load_unaligned;
@@ -323,9 +323,9 @@ namespace xsimd
         return *this;
     }
 
-    XSIMD_DEFINE_LOAD_STORE(float, 4, uint32_t, 16);
-    XSIMD_DEFINE_LOAD_STORE(float, 4, int64_t, 16);
-    XSIMD_DEFINE_LOAD_STORE(float, 4, uint64_t, 16);
+    XSIMD_DEFINE_LOAD_STORE(float, 4, uint32_t, 16)
+    XSIMD_DEFINE_LOAD_STORE(float, 4, int64_t, 16)
+    XSIMD_DEFINE_LOAD_STORE(float, 4, uint64_t, 16)
     XSIMD_DEFINE_LOAD_STORE_LONG(float, 4, 16)
 
     inline batch<float, 4>& batch<float, 4>::load_aligned(const float* src)

--- a/include/xsimd/types/xsimd_sse_int16.hpp
+++ b/include/xsimd/types/xsimd_sse_int16.hpp
@@ -102,8 +102,8 @@ namespace xsimd
         using base_class::store_aligned;
         using base_class::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT16(int16_t, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 8);
+        XSIMD_DECLARE_LOAD_STORE_INT16(int16_t, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 8)
     };
 
     template <>
@@ -118,8 +118,8 @@ namespace xsimd
         using base_class::store_aligned;
         using base_class::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT16(uint16_t, 8);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 8);
+        XSIMD_DECLARE_LOAD_STORE_INT16(uint16_t, 8)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 8)
     };
 
     batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int32_t rhs);

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -100,8 +100,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT32(int32_t, 4);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 4);
+        XSIMD_DECLARE_LOAD_STORE_INT32(int32_t, 4)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 4)
     };
 
     template <>
@@ -116,8 +116,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT32(uint32_t, 4);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 4);
+        XSIMD_DECLARE_LOAD_STORE_INT32(uint32_t, 4)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 4)
     };
 
     batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, int32_t rhs);

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -100,8 +100,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT64(int64_t, 2);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 2);
+        XSIMD_DECLARE_LOAD_STORE_INT64(int64_t, 2)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 2)
    };
 
     template <>
@@ -116,8 +116,8 @@ namespace xsimd
         using base_type::store_aligned;
         using base_type::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT64(uint64_t, 2);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 2);
+        XSIMD_DECLARE_LOAD_STORE_INT64(uint64_t, 2)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 2)
     };
 
     batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int32_t rhs);

--- a/include/xsimd/types/xsimd_sse_int8.hpp
+++ b/include/xsimd/types/xsimd_sse_int8.hpp
@@ -119,8 +119,8 @@ namespace xsimd
         {
         }
 
-        XSIMD_DECLARE_LOAD_STORE_INT8(int8_t, 16);
-        XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 16);
+        XSIMD_DECLARE_LOAD_STORE_INT8(int8_t, 16)
+        XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 16)
     };
 
     template <>
@@ -135,8 +135,8 @@ namespace xsimd
         using base_class::store_aligned;
         using base_class::store_unaligned;
 
-        XSIMD_DECLARE_LOAD_STORE_INT8(uint8_t, 16);
-        XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 16);
+        XSIMD_DECLARE_LOAD_STORE_INT8(uint8_t, 16)
+        XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 16)
     };
 
     batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int32_t rhs);


### PR DESCRIPTION
With this patch, -Wpedantic no longer produces warnings.