### PR TITLE
correction for batch_bool<T,.>::operator[] for avx/sse double/float

### DIFF
--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -132,9 +132,7 @@ namespace xsimd
 
     inline bool batch_bool<double, 4>::operator[](std::size_t index) const
     {
-        alignas(32) double x[4];
-        _mm256_store_pd(x, m_value);
-        return static_cast<bool>(x[index & 3]);
+        return reinterpret_cast<const std::uint64_t*>(&m_value)[index & 3];
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -136,9 +136,7 @@ namespace xsimd
 
     inline bool batch_bool<float, 8>::operator[](std::size_t index) const
     {
-        alignas(32) float x[8];
-        _mm256_store_ps(x, m_value);
-        return static_cast<bool>(x[index & 7]);
+        return reinterpret_cast<const std::uint32_t*>(&m_value)[index & 7];
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -130,9 +130,7 @@ namespace xsimd
 
     inline bool batch_bool<double, 2>::operator[](std::size_t index) const
     {
-        alignas(16) double x[2];
-        _mm_store_pd(x, m_value);
-        return static_cast<bool>(x[index & 1]);
+        return reinterpret_cast<const std::uint64_t*>(&m_value)[index & 1];
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -130,9 +130,7 @@ namespace xsimd
 
     inline bool batch_bool<float, 4>::operator[](std::size_t index) const
     {
-        alignas(16) float x[4];
-        _mm_store_ps(x, m_value);
-        return static_cast<bool>(x[index & 3]);
+        return reinterpret_cast<const std::uint32_t*>(&m_value)[index & 3];
     }
 
     namespace detail

--- a/test/xsimd_basic_test.hpp
+++ b/test/xsimd_basic_test.hpp
@@ -638,6 +638,7 @@ namespace xsimd
         vector_type rhs;
         vector_type mix_lhs_rhs;
         vector_type vres;
+        vector_bool_type bres;
         res_type res(tester_type::size);
         value_type s = tester.s;
         bool success = true;
@@ -913,6 +914,20 @@ namespace xsimd
         tmp_success = !all_res_false && all_res_true;
         success = success && tmp_success;
         success = success && test_simd_bool(vector_type(0.), out);
+
+        #define XSIMD_TEST_COMPARISON( OPERATOR ) \
+            topic = "operator" #OPERATOR "(simd, simd)  : "; \
+            bres = lhs OPERATOR rhs; \
+            for(std::size_t i=0;i<T::size;++i ) \
+                success &= ( lhs[ i ] OPERATOR rhs[ i ] ) == bres[ i ]
+        XSIMD_TEST_COMPARISON( <  );
+        XSIMD_TEST_COMPARISON( >  );
+        XSIMD_TEST_COMPARISON( <= );
+        XSIMD_TEST_COMPARISON( <= );
+        XSIMD_TEST_COMPARISON( == );
+        XSIMD_TEST_COMPARISON( != );
+        #undef XSIMD_TEST_COMPARISON
+
         return success;
     }
 


### PR DESCRIPTION
Hi there,

Many thanks for your fantastic library !

There's a small correction for `batch_bool<T,...>::operator[]` where `T` is a `float` or a `double`: sse and avx operations that give booleans (e.g. for `operator<`) actually fill all the bits in the results. If direclty read as a `double` or a `float`, it gives a `-nan` for a `true` or a `0` for a `false`, and unfortunately, these floating points values do not convert directly to the right boolean values :(

In the PR, there are some additionnal tests for this topic.

Best regards.
