### PR TITLE
Correction/rcast breaks aliasing

### DIFF
--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -132,7 +132,7 @@ namespace xsimd
 
     inline bool batch_bool<double, 4>::operator[](std::size_t index) const
     {
-        return reinterpret_cast<const std::uint64_t*>(&m_value)[index & 3];
+        return _mm256_extract_epi64(_mm256_castpd_si256(m_value), index & 3);
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -136,7 +136,7 @@ namespace xsimd
 
     inline bool batch_bool<float, 8>::operator[](std::size_t index) const
     {
-        return reinterpret_cast<const std::uint32_t*>(&m_value)[index & 7];
+        return _mm256_extract_epi32(_mm256_castps_si256(m_value), index & 7);
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -130,7 +130,7 @@ namespace xsimd
 
     inline bool batch_bool<double, 2>::operator[](std::size_t index) const
     {
-        return reinterpret_cast<const std::uint64_t*>(&m_value)[index & 1];
+        return _mm_extract_epi64(_mm_castpd_si128(m_value), index & 1);
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -130,7 +130,9 @@ namespace xsimd
 
     inline bool batch_bool<double, 2>::operator[](std::size_t index) const
     {
-        return _mm_extract_epi64(_mm_castpd_si128(m_value), index & 1);
+        double v = reinterpret_cast<const double *>(&m_value)[ index & 1 ];
+        std::uint64_t r = reinterpret_cast<std::uint64_t&>(v);
+        return r;
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -130,7 +130,9 @@ namespace xsimd
 
     inline bool batch_bool<float, 4>::operator[](std::size_t index) const
     {
-        return _mm_extract_epi32(_mm_castps_si128(m_value), index & 3);
+        float v = reinterpret_cast<const float *>(&m_value)[ index & 3 ];
+        std::uint32_t r = reinterpret_cast<std::uint32_t&>(v);
+        return r;
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -130,7 +130,7 @@ namespace xsimd
 
     inline bool batch_bool<float, 4>::operator[](std::size_t index) const
     {
-        return reinterpret_cast<const std::uint32_t*>(&m_value)[index & 3];
+        return _mm_extract_epi32(_mm_castps_si128(m_value), index & 3);
     }
 
     namespace detail


### PR DESCRIPTION
Hi there,

There's a correction (again, sorry) for `batch_bool<T,.>::operator[]` for avx/sse double/float: a direct `reinterpret_cast<&...>` may break the implicit aliasing rules of the modern optimizing compilers. For instance, with g++, `batch_bool<T,.>::operator[]` works now with `-ffast-math` and `-O6` (it was actually not always the case before).

Best regards.