### PR TITLE
Fix lax vector conversion and GCC/Clang multiply bug.

### DIFF
--- a/include/xsimd/types/xsimd_neon_int16.hpp
+++ b/include/xsimd/types/xsimd_neon_int16.hpp
@@ -162,7 +162,7 @@ namespace xsimd
 
     inline batch<int16_t, 8>& batch<int16_t, 8>::load_aligned(const uint16_t* src)
     {
-        m_value = vld1q_u16(src);
+        m_value = vreinterpretq_s16_u16(vld1q_u16(src));
         return *this;
     }
 
@@ -183,7 +183,7 @@ namespace xsimd
 
     inline void batch<int16_t, 8>::store_aligned(uint16_t* dst) const
     {
-        vst1q_u16(dst, m_value);
+        vst1q_u16(dst, vreinterpretq_u16_s16(m_value));
     }
 
     inline void batch<int16_t, 8>::store_unaligned(uint16_t* dst) const
@@ -387,7 +387,7 @@ namespace xsimd
 
     inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
     {
-        return vshlq_s8(lhs, rhs);
+        return vshlq_s16(lhs, rhs);
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_int8.hpp
+++ b/include/xsimd/types/xsimd_neon_int8.hpp
@@ -161,7 +161,7 @@ namespace xsimd
 
     inline batch<int8_t, 16>& batch<int8_t, 16>::load_aligned(const uint8_t* src)
     {
-        m_value = vld1q_u8(src);
+        m_value = vreinterpretq_s8_u8(vld1q_u8(src));
         return *this;
     }
 
@@ -182,7 +182,7 @@ namespace xsimd
 
     inline void batch<int8_t, 16>::store_aligned(uint8_t* dst) const
     {
-        vst1q_u8(dst, m_value);
+        vst1q_u8(dst, vreinterpretq_u8_s8(m_value));
     }
 
     inline void batch<int8_t, 16>::store_unaligned(uint8_t* dst) const

--- a/include/xsimd/types/xsimd_neon_uint16.hpp
+++ b/include/xsimd/types/xsimd_neon_uint16.hpp
@@ -133,7 +133,7 @@ namespace xsimd
 
     inline batch<uint16_t, 8>& batch<uint16_t, 8>::load_aligned(const int16_t* src)
     {
-        m_value = vld1q_s16(src);
+        m_value = vreinterpretq_u16_s16(vld1q_s16(src));
         return *this;
     }
 
@@ -156,7 +156,7 @@ namespace xsimd
 
     inline void batch<uint16_t, 8>::store_aligned(int16_t* dst) const
     {
-        vst1q_s16(dst, m_value);
+        vst1q_s16(dst, vreinterpretq_s16_u16(m_value));
     }
 
     inline void batch<uint16_t, 8>::store_unaligned(int16_t* dst) const
@@ -316,7 +316,7 @@ namespace xsimd
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
                 return vaddvq_u16(rhs);
 #else
-                int16x4_t tmp = vpadd_u16(vget_low_u16(rhs), vget_high_u16(rhs));
+                uint16x4_t tmp = vpadd_u16(vget_low_u16(rhs), vget_high_u16(rhs));
                 value_type res = 0;
                 for (std::size_t i = 0; i < 4; ++i)
                 {

--- a/include/xsimd/types/xsimd_neon_uint8.hpp
+++ b/include/xsimd/types/xsimd_neon_uint8.hpp
@@ -131,7 +131,7 @@ namespace xsimd
 
     inline batch<uint8_t, 16>& batch<uint8_t, 16>::load_aligned(const int8_t* src)
     {
-        m_value = vld1q_s8(src);
+        m_value = vreinterpretq_u8_s8(vld1q_s8(src));
         return *this;
     }
 
@@ -154,7 +154,7 @@ namespace xsimd
 
     inline void batch<uint8_t, 16>::store_aligned(int8_t* dst) const
     {
-        vst1q_s8(dst, m_value);
+        vst1q_s8(dst, vreinterpretq_s8_u8(m_value));
     }
 
     inline void batch<uint8_t, 16>::store_unaligned(int8_t* dst) const
@@ -315,7 +315,7 @@ namespace xsimd
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
                 return vaddvq_u8(rhs);
 #else
-                int8x8_t tmp = vpadd_u8(vget_low_u8(rhs), vget_high_u8(rhs));
+                uint8x8_t tmp = vpadd_u8(vget_low_u8(rhs), vget_high_u8(rhs));
                 value_type res = 0;
                 for (std::size_t i = 0; i < 8; ++i)
                 {
@@ -369,7 +369,7 @@ namespace xsimd
 
     inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, const batch<uint8_t, 16>& rhs)
     {
-        return vshlq_u8(lhs, rhs);
+        return vshlq_u8(lhs, vreinterpretq_s8_u8(rhs));
     }
 
 }


### PR DESCRIPTION
Notes are in the commit messages.

GCC no longer needs `-flax-vector-conversion`.  I fixed the implicit casts.

In addition, I used intrinsics in `mul` for uint64 on NEON 32. The issue here is that both Clang and GCC will incorrectly switch to scalar multiply, which is slower than the pure NEON alternative on ARMv7a. 

I would like someone to benchmark the modified `mul` code on an aarch64 device. I have it disabled because I assume it would be slower like the same approach on x86_64, but I could be wrong. 

I commented the equivalent C code in the function, as the intrinsics can be a little hard to follow. The intrinsics are required, though, as it is apparently impossible without them.