### PR TITLE
union { __mxxxd reg; array<int_type,N> arr; } for batch_bool, AVX/SSE

### DIFF
--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -43,8 +43,12 @@ namespace xsimd
         bool operator[](std::size_t index) const;
 
     private:
+        union storage_t {
+            std::array<std::uint64_t, 4> arr;
+            __m256d                      reg;
+        };
 
-        __m256d m_value;
+        storage_t m_value;
     };
 
     /********************
@@ -103,38 +107,36 @@ namespace xsimd
     }
 
     inline batch_bool<double, 4>::batch_bool(bool b)
-        : m_value(_mm256_castsi256_pd(_mm256_set1_epi32(-(int)b)))
     {
+        m_value.reg=_mm256_castsi256_pd(_mm256_set1_epi32(-(int)b));
     }
 
     inline batch_bool<double, 4>::batch_bool(bool b0, bool b1, bool b2, bool b3)
-        : m_value(_mm256_castsi256_pd(
-              _mm256_setr_epi32(-(int)b0, -(int)b0, -(int)b1, -(int)b1,
-                                -(int)b2, -(int)b2, -(int)b3, -(int)b3)))
     {
+        m_value.reg=_mm256_castsi256_pd(
+                    _mm256_setr_epi32(-(int)b0, -(int)b0, -(int)b1, -(int)b1,
+                                      -(int)b2, -(int)b2, -(int)b3, -(int)b3));
     }
 
     inline batch_bool<double, 4>::batch_bool(const __m256d& rhs)
-        : m_value(rhs)
     {
+        m_value.reg=rhs;
     }
 
     inline batch_bool<double, 4>& batch_bool<double, 4>::operator=(const __m256d& rhs)
     {
-        m_value = rhs;
+        m_value.reg = rhs;
         return *this;
     }
 
     inline batch_bool<double, 4>::operator __m256d() const
     {
-        return m_value;
+        return m_value.reg;
     }
 
     inline bool batch_bool<double, 4>::operator[](std::size_t index) const
     {
-        double v = reinterpret_cast<const double*>(&m_value)[index & 3];
-        std::uint64_t r = reinterpret_cast<std::uint64_t&>(v);
-        return (bool)r;
+        return bool(m_value.arr[index & 3]);
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -10,6 +10,7 @@
 #define XSIMD_AVX_DOUBLE_HPP
 
 #include "xsimd_base.hpp"
+#include <array>
 
 namespace xsimd
 {
@@ -43,7 +44,8 @@ namespace xsimd
         bool operator[](std::size_t index) const;
 
     private:
-        union storage_t {
+        union storage_t
+        {
             std::array<std::uint64_t, 4> arr;
             __m256d                      reg;
         };
@@ -108,19 +110,19 @@ namespace xsimd
 
     inline batch_bool<double, 4>::batch_bool(bool b)
     {
-        m_value.reg=_mm256_castsi256_pd(_mm256_set1_epi32(-(int)b));
+        m_value.reg = _mm256_castsi256_pd(_mm256_set1_epi32(-(int)b));
     }
 
     inline batch_bool<double, 4>::batch_bool(bool b0, bool b1, bool b2, bool b3)
     {
-        m_value.reg=_mm256_castsi256_pd(
+        m_value.reg = _mm256_castsi256_pd(
                     _mm256_setr_epi32(-(int)b0, -(int)b0, -(int)b1, -(int)b1,
                                       -(int)b2, -(int)b2, -(int)b3, -(int)b3));
     }
 
     inline batch_bool<double, 4>::batch_bool(const __m256d& rhs)
     {
-        m_value.reg=rhs;
+        m_value.reg = rhs;
     }
 
     inline batch_bool<double, 4>& batch_bool<double, 4>::operator=(const __m256d& rhs)

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -11,6 +11,7 @@
 
 #include "xsimd_base.hpp"
 #include "xsimd_int_conversion.hpp"
+#include <array>
 
 namespace xsimd
 {
@@ -45,7 +46,8 @@ namespace xsimd
         bool operator[](std::size_t index) const;
 
     private:
-        union storage_t {
+        union storage_t
+        {
             std::array<std::uint32_t, 8> arr;
             __m256                       reg;
         };
@@ -111,20 +113,20 @@ namespace xsimd
 
     inline batch_bool<float, 8>::batch_bool(bool b)
     {
-        m_value.reg=_mm256_castsi256_ps(_mm256_set1_epi32(-(int)b));
+        m_value.reg = _mm256_castsi256_ps(_mm256_set1_epi32(-(int)b));
     }
 
     inline batch_bool<float, 8>::batch_bool(bool b0, bool b1, bool b2, bool b3,
                                             bool b4, bool b5, bool b6, bool b7)
     {
-        m_value.reg=_mm256_castsi256_ps(
+        m_value.reg = _mm256_castsi256_ps(
               _mm256_setr_epi32(-(int)b0, -(int)b1, -(int)b2, -(int)b3,
                                 -(int)b4, -(int)b5, -(int)b6, -(int)b7));
     }
 
     inline batch_bool<float, 8>::batch_bool(const __m256& rhs)
     {
-        m_value.reg=rhs;
+        m_value.reg = rhs;
     }
 
     inline batch_bool<float, 8>& batch_bool<float, 8>::operator=(const __m256& rhs)

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -45,8 +45,12 @@ namespace xsimd
         bool operator[](std::size_t index) const;
 
     private:
+        union storage_t {
+            std::array<std::uint32_t, 8> arr;
+            __m256                       reg;
+        };
 
-        __m256 m_value;
+        storage_t m_value;
     };
 
     /*******************
@@ -106,39 +110,37 @@ namespace xsimd
     }
 
     inline batch_bool<float, 8>::batch_bool(bool b)
-        : m_value(_mm256_castsi256_ps(_mm256_set1_epi32(-(int)b)))
     {
+        m_value.reg=_mm256_castsi256_ps(_mm256_set1_epi32(-(int)b));
     }
 
     inline batch_bool<float, 8>::batch_bool(bool b0, bool b1, bool b2, bool b3,
                                             bool b4, bool b5, bool b6, bool b7)
-        : m_value(_mm256_castsi256_ps(
-              _mm256_setr_epi32(-(int)b0, -(int)b1, -(int)b2, -(int)b3,
-                                -(int)b4, -(int)b5, -(int)b6, -(int)b7)))
     {
+        m_value.reg=_mm256_castsi256_ps(
+              _mm256_setr_epi32(-(int)b0, -(int)b1, -(int)b2, -(int)b3,
+                                -(int)b4, -(int)b5, -(int)b6, -(int)b7));
     }
 
     inline batch_bool<float, 8>::batch_bool(const __m256& rhs)
-        : m_value(rhs)
     {
+        m_value.reg=rhs;
     }
 
     inline batch_bool<float, 8>& batch_bool<float, 8>::operator=(const __m256& rhs)
     {
-        m_value = rhs;
+        m_value.reg = rhs;
         return *this;
     }
 
     inline batch_bool<float, 8>::operator __m256() const
     {
-        return m_value;
+        return m_value.reg;
     }
 
     inline bool batch_bool<float, 8>::operator[](std::size_t index) const
     {
-        float v = reinterpret_cast<const float*>(&m_value)[index & 7];
-        std::uint32_t r = reinterpret_cast<std::uint32_t&>(v);
-        return (bool)r;
+        return bool(m_value.arr[index & 7]);
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -44,7 +44,12 @@ namespace xsimd
 
     private:
 
-        __m128d m_value;
+        union storage_t {
+            std::array<std::uint64_t, 2> arr;
+            __m128d                      reg;
+        };
+
+        storage_t m_value;
     };
 
     /********************
@@ -103,36 +108,34 @@ namespace xsimd
     }
 
     inline batch_bool<double, 2>::batch_bool(bool b)
-        : m_value(_mm_castsi128_pd(_mm_set1_epi32(-(int)b)))
     {
+        m_value.reg=_mm_castsi128_pd(_mm_set1_epi32(-(int)b));
     }
 
     inline batch_bool<double, 2>::batch_bool(bool b0, bool b1)
-        : m_value(_mm_castsi128_pd(_mm_setr_epi32(-(int)b0, -(int)b0, -(int)b1, -(int)b1)))
     {
+        m_value.reg=_mm_castsi128_pd(_mm_setr_epi32(-(int)b0, -(int)b0, -(int)b1, -(int)b1));
     }
 
     inline batch_bool<double, 2>::batch_bool(const __m128d& rhs)
-        : m_value(rhs)
     {
+        m_value.reg=rhs;
     }
 
     inline batch_bool<double, 2>& batch_bool<double, 2>::operator=(const __m128d& rhs)
     {
-        m_value = rhs;
+        m_value.reg = rhs;
         return *this;
     }
 
     inline batch_bool<double, 2>::operator __m128d() const
     {
-        return m_value;
+        return m_value.reg;
     }
 
     inline bool batch_bool<double, 2>::operator[](std::size_t index) const
     {
-        double v = reinterpret_cast<const double *>(&m_value)[index & 1];
-        std::uint64_t r = reinterpret_cast<std::uint64_t&>(v);
-        return (bool)r;
+        return bool(m_value.arr[index & 1]);
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -10,6 +10,7 @@
 #define XSIMD_SSE_DOUBLE_HPP
 
 #include "xsimd_base.hpp"
+#include <array>
 
 namespace xsimd
 {
@@ -44,7 +45,8 @@ namespace xsimd
 
     private:
 
-        union storage_t {
+        union storage_t
+        {
             std::array<std::uint64_t, 2> arr;
             __m128d                      reg;
         };
@@ -109,17 +111,17 @@ namespace xsimd
 
     inline batch_bool<double, 2>::batch_bool(bool b)
     {
-        m_value.reg=_mm_castsi128_pd(_mm_set1_epi32(-(int)b));
+        m_value.reg = _mm_castsi128_pd(_mm_set1_epi32(-(int)b));
     }
 
     inline batch_bool<double, 2>::batch_bool(bool b0, bool b1)
     {
-        m_value.reg=_mm_castsi128_pd(_mm_setr_epi32(-(int)b0, -(int)b0, -(int)b1, -(int)b1));
+        m_value.reg = _mm_castsi128_pd(_mm_setr_epi32(-(int)b0, -(int)b0, -(int)b1, -(int)b1));
     }
 
     inline batch_bool<double, 2>::batch_bool(const __m128d& rhs)
     {
-        m_value.reg=rhs;
+        m_value.reg = rhs;
     }
 
     inline batch_bool<double, 2>& batch_bool<double, 2>::operator=(const __m128d& rhs)

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -43,8 +43,12 @@ namespace xsimd
         bool operator[](std::size_t index) const;
 
     private:
+        union storage_t {
+            std::array<std::uint32_t, 4> arr;
+            __m128                       reg;
+        };
 
-        __m128 m_value;
+        storage_t m_value;
     };
 
     /*******************
@@ -103,36 +107,34 @@ namespace xsimd
     }
 
     inline batch_bool<float, 4>::batch_bool(bool b)
-        : m_value(_mm_castsi128_ps(_mm_set1_epi32(-(int)b)))
     {
+        m_value.reg=_mm_castsi128_ps(_mm_set1_epi32(-(int)b));
     }
 
     inline batch_bool<float, 4>::batch_bool(bool b0, bool b1, bool b2, bool b3)
-        : m_value(_mm_castsi128_ps(_mm_setr_epi32(-(int)b0, -(int)b1, -(int)b2, -(int)b3)))
     {
+        m_value.reg=_mm_castsi128_ps(_mm_setr_epi32(-(int)b0, -(int)b1, -(int)b2, -(int)b3));
     }
 
     inline batch_bool<float, 4>::batch_bool(const __m128& rhs)
-        : m_value(rhs)
     {
+        m_value.reg=rhs;
     }
 
     inline batch_bool<float, 4>& batch_bool<float, 4>::operator=(const __m128& rhs)
     {
-        m_value = rhs;
+        m_value.reg = rhs;
         return *this;
     }
 
     inline batch_bool<float, 4>::operator __m128() const
     {
-        return m_value;
+        return m_value.reg;
     }
 
     inline bool batch_bool<float, 4>::operator[](std::size_t index) const
     {
-        float v = reinterpret_cast<const float *>(&m_value)[index & 3];
-        std::uint32_t r = reinterpret_cast<std::uint32_t&>(v);
-        return (bool)r;
+        return bool(m_value.arr[index & 3]);
     }
 
     namespace detail

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -10,6 +10,7 @@
 #define XSIMD_SSE_FLOAT_HPP
 
 #include "xsimd_base.hpp"
+#include <array>
 
 namespace xsimd
 {
@@ -43,7 +44,8 @@ namespace xsimd
         bool operator[](std::size_t index) const;
 
     private:
-        union storage_t {
+        union storage_t
+        {
             std::array<std::uint32_t, 4> arr;
             __m128                       reg;
         };
@@ -108,17 +110,17 @@ namespace xsimd
 
     inline batch_bool<float, 4>::batch_bool(bool b)
     {
-        m_value.reg=_mm_castsi128_ps(_mm_set1_epi32(-(int)b));
+        m_value.reg = _mm_castsi128_ps(_mm_set1_epi32(-(int)b));
     }
 
     inline batch_bool<float, 4>::batch_bool(bool b0, bool b1, bool b2, bool b3)
     {
-        m_value.reg=_mm_castsi128_ps(_mm_setr_epi32(-(int)b0, -(int)b1, -(int)b2, -(int)b3));
+        m_value.reg = _mm_castsi128_ps(_mm_setr_epi32(-(int)b0, -(int)b1, -(int)b2, -(int)b3));
     }
 
     inline batch_bool<float, 4>::batch_bool(const __m128& rhs)
     {
-        m_value.reg=rhs;
+        m_value.reg = rhs;
     }
 
     inline batch_bool<float, 4>& batch_bool<float, 4>::operator=(const __m128& rhs)


### PR DESCRIPTION
Hi there,

As discussed in a previous pull request, there's a proposition where for AVX and SSE, `batch_bool<floating point,N>` attributes become unions. These unions contain either a SIMD type or an array to allow selection by index (and then to be able to forward `array.begin()`, `array.end()`, etc...).

It has been done only for batch_bool, floating points and AVX/SSE. I guess that to be coherent, it would be nice to do the same thing for generic batches and other SIMD instruction sets... but I wanted to be sure to be on the right track before changing everything (and exposing the world to bad things :) ).

For `batch_bool`, taking an array of ints solves the problem with `-ffast-math` (which changes the conversion value of `nan` to `bool`). In this case, the potential aliasing issue is naturally solved: `__mxxx` types, even if suffixed with `d` are not assumed to contain only a given class of values. For an example: [https://godbolt.org/z/LO35aw](https://godbolt.org/z/LO35aw) (where the return of `h` is optimized, which is not the case for `g`, even if operations are purely on doubles :) ).

For execution time, I tested on simple cases and haven't seen any difference. Besides, it may be good to add some benchmarks for some `batch_bool` operations (and maybe add some tzcnt or popcnt kinds of operations).

