### PR TITLE
Adding stl style reduce algorithm with tests.

### DIFF
--- a/include/xsimd/stl/algorithms.hpp
+++ b/include/xsimd/stl/algorithms.hpp
@@ -126,4 +126,63 @@ namespace xsimd
 
         #undef XSIMD_LOOP_MACRO
     }
+
+
+    // TODO: Remove this once we drop C++11 support
+    namespace detail
+    {
+        struct plus
+        {
+            template <class X, class Y>
+            auto operator()(X&& x, Y&& y) -> decltype(x + y) { return x + y; }
+        };
+    }
+
+
+    template <class Iterator1, class Iterator2, class Init, class BinaryFunction = detail::plus>
+    Init reduce(Iterator1 first, Iterator2 last, Init init, BinaryFunction&& binfun = detail::plus{})
+    {
+        using value_type = typename std::decay<decltype(*first)>::type;
+        using traits = simd_traits<value_type>;
+        using batch_type = typename traits::type;
+
+        std::size_t size = static_cast<std::size_t>(std::distance(first, last));
+        constexpr std::size_t simd_size = traits::size;
+
+        const auto* const ptr_begin = &(*first);
+
+        std::size_t align_begin = xsimd::get_alignment_offset(ptr_begin, size, simd_size);
+        std::size_t align_end = align_begin + ((size - align_begin) & ~(simd_size - 1));
+
+        // reduce initial unaligned part
+        for (std::size_t i = 0; i < align_begin; ++i)
+        {
+            init = binfun(init, first[i]);
+        }
+
+        // reduce aligned part
+        batch_type batch_init, batch;
+        auto ptr = ptr_begin + align_begin;
+        xsimd::load_aligned(ptr, batch_init);
+        ptr += simd_size;
+        for (auto const end = ptr_begin + align_end; ptr < end; ptr += simd_size)
+        {
+            xsimd::load_aligned(ptr, batch);
+            batch_init = binfun(batch_init, batch);
+        }
+
+        // reduce across batch
+        alignas(batch_type) std::array<value_type, simd_size> arr;
+        xsimd::store_aligned(arr.data(), batch_init);
+        for (auto x : arr) init = binfun(init, x);
+
+        // reduce final unaligned part
+        for (std::size_t i = align_end; i < size; ++i)
+        {
+            init = binfun(init, first[i]);
+        }
+
+        return init;
+    }
+
 }

--- a/test/xsimd_algorithms.cpp
+++ b/test/xsimd_algorithms.cpp
@@ -8,6 +8,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <numeric>
 
 #include "xsimd/xsimd.hpp"
 
@@ -15,95 +16,157 @@
 
 struct binary_functor
 {
-	template <class T>
-	T operator()(const T& a, const T& b) const
-	{
-		return a + b;
-	}
+    template <class T>
+    T operator()(const T& a, const T& b) const
+    {
+        return a + b;
+    }
 };
 
 struct unary_functor
 {
-	template <class T>
-	T operator()(const T& a) const
-	{
-		return -a;
-	}
+    template <class T>
+    T operator()(const T& a) const
+    {
+        return -a;
+    }
 };
 
 TEST(xsimd, binary_transform)
 {
-	std::vector<double> expected(93);
+    std::vector<double> expected(93);
 
-	std::vector<double> a(93, 123), b(93, 123), c(93);
-	std::vector<double, xsimd::aligned_allocator<double, XSIMD_DEFAULT_ALIGNMENT>> aa(93, 123), ba(93, 123), ca(93);
+    std::vector<double> a(93, 123), b(93, 123), c(93);
+    std::vector<double, xsimd::aligned_allocator<double, XSIMD_DEFAULT_ALIGNMENT>> aa(93, 123), ba(93, 123), ca(93);
 
-	std::transform(a.begin(), a.end(), b.begin(), expected.begin(),
-					binary_functor{});
+    std::transform(a.begin(), a.end(), b.begin(), expected.begin(),
+                    binary_functor{});
 
-	xsimd::transform(a.begin(), a.end(), b.begin(), c.begin(),
-					 binary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
-	std::fill(c.begin(), c.end(), -1); // erase
+    xsimd::transform(a.begin(), a.end(), b.begin(), c.begin(),
+                     binary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
+    std::fill(c.begin(), c.end(), -1); // erase
 
-	xsimd::transform(aa.begin(), aa.end(), ba.begin(), c.begin(),
-					 binary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
-	std::fill(c.begin(), c.end(), -1); // erase
+    xsimd::transform(aa.begin(), aa.end(), ba.begin(), c.begin(),
+                     binary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
+    std::fill(c.begin(), c.end(), -1); // erase
 
-	xsimd::transform(aa.begin(), aa.end(), b.begin(), c.begin(),
-					 binary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
-	std::fill(c.begin(), c.end(), -1); // erase
+    xsimd::transform(aa.begin(), aa.end(), b.begin(), c.begin(),
+                     binary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
+    std::fill(c.begin(), c.end(), -1); // erase
 
-	xsimd::transform(a.begin(), a.end(), ba.begin(), c.begin(),
-					 binary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
-	std::fill(c.begin(), c.end(), -1); // erase
+    xsimd::transform(a.begin(), a.end(), ba.begin(), c.begin(),
+                     binary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
+    std::fill(c.begin(), c.end(), -1); // erase
 
-	xsimd::transform(aa.begin(), aa.end(), ba.begin(), ca.begin(),
-					 binary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
-	std::fill(ca.begin(), ca.end(), -1); // erase
+    xsimd::transform(aa.begin(), aa.end(), ba.begin(), ca.begin(),
+                     binary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
+    std::fill(ca.begin(), ca.end(), -1); // erase
 
-	xsimd::transform(aa.begin(), aa.end(), b.begin(), ca.begin(),
-					 binary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
-	std::fill(ca.begin(), ca.end(), -1); // erase
+    xsimd::transform(aa.begin(), aa.end(), b.begin(), ca.begin(),
+                     binary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
+    std::fill(ca.begin(), ca.end(), -1); // erase
 
-	xsimd::transform(a.begin(), a.end(), ba.begin(), ca.begin(),
-					 binary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
-	std::fill(ca.begin(), ca.end(), -1); // erase
+    xsimd::transform(a.begin(), a.end(), ba.begin(), ca.begin(),
+                     binary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
+    std::fill(ca.begin(), ca.end(), -1); // erase
 }
 
 
 TEST(xsimd, unary_transform)
 {
-	std::vector<double> expected(93);
-	std::vector<double> a(93, 123), c(93);
-	std::vector<double, xsimd::aligned_allocator<double, XSIMD_DEFAULT_ALIGNMENT>> aa(93, 123), ca(93);
+    std::vector<double> expected(93);
+    std::vector<double> a(93, 123), c(93);
+    std::vector<double, xsimd::aligned_allocator<double, XSIMD_DEFAULT_ALIGNMENT>> aa(93, 123), ca(93);
 
-	std::transform(a.begin(), a.end(), expected.begin(),
-				   unary_functor{});
+    std::transform(a.begin(), a.end(), expected.begin(),
+                   unary_functor{});
 
-	xsimd::transform(a.begin(), a.end(), c.begin(),
-					 unary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
-	std::fill(c.begin(), c.end(), -1); // erase
+    xsimd::transform(a.begin(), a.end(), c.begin(),
+                     unary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
+    std::fill(c.begin(), c.end(), -1); // erase
 
-	xsimd::transform(aa.begin(), aa.end(), c.begin(),
-					 unary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
-	std::fill(c.begin(), c.end(), -1); // erase
+    xsimd::transform(aa.begin(), aa.end(), c.begin(),
+                     unary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), c.begin()) && expected.size() == c.size());
+    std::fill(c.begin(), c.end(), -1); // erase
 
-	xsimd::transform(a.begin(), a.end(), ca.begin(),
-					 unary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
-	std::fill(ca.begin(), ca.end(), -1); // erase
+    xsimd::transform(a.begin(), a.end(), ca.begin(),
+                     unary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
+    std::fill(ca.begin(), ca.end(), -1); // erase
 
-	xsimd::transform(aa.begin(), aa.end(), ca.begin(),
-					 unary_functor{});
-	EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
-	std::fill(ca.begin(), ca.end(), -1); // erase
+    xsimd::transform(aa.begin(), aa.end(), ca.begin(),
+                     unary_functor{});
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
+    std::fill(ca.begin(), ca.end(), -1); // erase
+}
+
+
+
+class xsimd_reduce : public ::testing::Test
+{
+public:
+    using aligned_vec_t = std::vector<double, xsimd::aligned_allocator<double, XSIMD_DEFAULT_ALIGNMENT>>;
+
+    static constexpr std::size_t num_elements = 4 * xsimd::simd_traits<double>::size;
+
+    aligned_vec_t  vec = aligned_vec_t(num_elements, 123.);
+    double         init = 1337.;
+
+    struct multiply
+    {
+        template <class T>
+        T operator()(const T& a, const T& b) const
+        {
+            return a * b;
+        }
+    };
+};
+
+TEST_F(xsimd_reduce, unaligned_begin_unaligned_end)
+{
+    auto const begin = std::next(vec.begin());
+    auto const end = std::prev(vec.end());
+
+    EXPECT_EQ(std::accumulate(begin, end, init), xsimd::reduce(begin, end, init));
+}
+
+TEST_F(xsimd_reduce, unaligned_begin_aligned_end)
+{
+    auto const begin = std::next(vec.begin());
+    auto const end = vec.end();
+
+    EXPECT_EQ(std::accumulate(begin, end, init), xsimd::reduce(begin, end, init));
+}
+
+TEST_F(xsimd_reduce, aligned_begin_unaligned_end)
+{
+    auto const begin = vec.begin();
+    auto const end = std::prev(vec.end());
+
+    EXPECT_EQ(std::accumulate(begin, end, init), xsimd::reduce(begin, end, init));
+}
+
+TEST_F(xsimd_reduce, aligned_begin_aligned_end)
+{
+    auto const begin = vec.begin();
+    auto const end = vec.end();
+
+    EXPECT_EQ(std::accumulate(begin, end, init), xsimd::reduce(begin, end, init));
+}
+
+TEST_F(xsimd_reduce, using_custom_binary_function)
+{
+    auto const begin = vec.begin();
+    auto const end = vec.end();
+
+    EXPECT_EQ(std::accumulate(begin, end, init, multiply{}), xsimd::reduce(begin, end, init, multiply{}));
 }


### PR DESCRIPTION
I've add another missing STL algorithm to the algorithm header: `reduce` along with unit tests.