### PR TITLE
Add missing include guard for algorithms.hpp

### DIFF
--- a/include/xsimd/stl/algorithms.hpp
+++ b/include/xsimd/stl/algorithms.hpp
@@ -6,6 +6,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#ifndef XSIMD_ALGORITHMS_HPP
+#define XSIMD_ALGORITHMS_HPP
+
 #include "xsimd/memory/xsimd_load_store.hpp"
 
 namespace xsimd
@@ -186,3 +189,5 @@ namespace xsimd
     }
 
 }
+
+#endif


### PR DESCRIPTION
```
  C:\[...]\include\xsimd/stl/algorithms.hpp(69): error C2995: 'void xsimd::
transform(I1,I2,O1,UF &&)': function template has already been defined [...]
  C:\[...]\include\xsimd/stl/algorithms.hpp(128): error C2995: 'void xsimd:
:transform(I1,I2,I3,O1,UF &&)': function template has already been defined [...]
```

Please consider releasing a new version right after merging this...