### PR TITLE
Do not dereference end iterators

### DIFF
--- a/include/xsimd/stl/algorithms.hpp
+++ b/include/xsimd/stl/algorithms.hpp
@@ -24,7 +24,6 @@ namespace xsimd
         std::size_t simd_size = traits::size;
 
         const auto* ptr_begin = &(*first);
-        const auto* ptr_end = &(*last);
         auto* ptr_out = &(*out_first);
 
         std::size_t align_begin = xsimd::get_alignment_offset(ptr_begin, size, simd_size);
@@ -83,7 +82,6 @@ namespace xsimd
 
         const auto* ptr_begin_1 = &(*first_1);
         const auto* ptr_begin_2 = &(*first_2);
-        const auto* ptr_end = &(*last_1);
         auto* ptr_out = &(*out_first);
 
         std::size_t align_begin_1 = xsimd::get_alignment_offset(ptr_begin_1, size, simd_size);


### PR DESCRIPTION
It causes exceptions in MSVC STL in Debug config when debug
iterators are enabled (default).